### PR TITLE
Implementar Feltrim Agents como assistente guiado

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback_sofia_claudia.md
+++ b/.github/ISSUE_TEMPLATE/feedback_sofia_claudia.md
@@ -1,0 +1,68 @@
+---
+name: Feedback Sofia/Claudia
+about: Registrar feedback operacional sobre SIBiSC/Feltrim Agents
+title: "[FEEDBACK] "
+labels: feedback, qa
+assignees: ''
+---
+
+## Recebimento
+
+- Recebido por: Sofia / Claudia
+- Data e hora:
+- Rota/tela:
+- Ambiente: local / preview / producao
+- Dispositivo, navegador e viewport:
+
+## Tipo de feedback
+
+- [ ] Linguagem ou compreensao
+- [ ] Recomendacao ruim ou pouco explicavel
+- [ ] Disponibilidade mockada pouco clara
+- [ ] Ausencia de reserva real pouco clara
+- [ ] Acessibilidade ou teclado
+- [ ] Mobile/responsividade
+- [ ] Dado, link ou rota quebrada
+- [ ] Outro:
+
+## Relato
+
+Descreva o feedback de forma objetiva, sem incluir dados pessoais desnecessarios.
+
+## Passos para reproduzir
+
+1.
+2.
+3.
+
+## Esperado
+
+O que a pessoa esperava ver ou conseguir fazer?
+
+## Observado
+
+O que aconteceu de fato?
+
+## Evidencias
+
+- Print/video/log:
+- Texto exato exibido:
+- Livro/evento/noticia relacionado, se houver:
+- `bookId`/`eventId`/`newsId`, se houver:
+
+## Triagem
+
+- Impacto percebido por Sofia:
+- Contexto operacional registrado por Claudia:
+- Severidade tecnica sugerida por QA: P0 / P1 / P2 / P3
+- Prioridade de produto sugerida: P0 / P1 / P2 / P3
+- Dono:
+- Status: recebido / em reproducao / em correcao / validado / fechado / nao aplicavel
+
+## Criterio de fechamento
+
+- [ ] QA conseguiu reproduzir ou declarou nao reproduzivel com justificativa.
+- [ ] Produto decidiu prioridade ou encerramento.
+- [ ] Quando houve correcao, QA revalidou com Dev.
+- [ ] Sofia/Claudia possuem retorno claro para a pessoa que relatou.
+- [ ] Nao foram registrados segredos, tokens ou dados pessoais desnecessarios.

--- a/SIBiSC/docs/product/matriz_perguntas_guiadas_sprint1.md
+++ b/SIBiSC/docs/product/matriz_perguntas_guiadas_sprint1.md
@@ -1,0 +1,40 @@
+# Matriz de perguntas guiadas - Sprint 1
+
+Data: 2026-05-19  
+Escopo: Feltrim Agents como assistente guiado, sem chat aberto, IA generativa, backend real, reserva real ou integracao oficial SIBI/PHL.
+
+## Texto base obrigatorio
+
+> Esta resposta usa dados locais do prototipo. A disponibilidade nao substitui confirmacao oficial da biblioteca e ainda nao ha reserva real nesta versao.
+
+## Perguntas aprovadas para o incremento inicial
+
+| ID | Pergunta guiada | Fonte local | Motivo exibido | Proxima acao | Limite comunicado |
+| --- | --- | --- | --- | --- | --- |
+| `literatura-brasileira` | Quero uma leitura de literatura brasileira | `catalogo-mock` + preferencias demonstrativas | Autor/categoria nas preferencias do perfil mockado | Abrir detalhe de `b7` ou `b3`; explorar catalogo | Disponibilidade mockada, sem reserva real |
+| `machado-de-assis` | Tenho interesse em Machado de Assis | `src/mocks/books.js` | Autor corresponde diretamente ao interesse informado | Abrir `b3` ou `b1`; buscar no catalogo | Nao consulta catalogo oficial |
+| `cidade-sociedade` | Procuro temas de cidade e sociedade | `src/mocks/books.js` | Resumos de `b2` e `b5` citam cidade, desigualdade ou tensoes sociais | Abrir livros no catalogo | Resultado depende do acervo local mockado |
+| `confirmar-disponibilidade` | Como vejo disponibilidade sem reservar? | Inventario local mockado | Exemplo usa contagem local de `b7` | Abrir catalogo/detalhe para ver unidades | Disponibilidade nao e oficial e nao gera reserva |
+| `eventos-leitura` | Quais eventos combinam com leitura? | `src/mocks/events.js` | Eventos mencionam clube, roda ou livro do catalogo | Abrir `e3`, `e7` ou agenda completa | Data/horario/inscricao devem ser confirmados |
+| `noticias-servicos` | Quero entender novidades e servicos | `src/mocks/news.js` | Noticias contextualizam orientacao digital e acervo | Abrir `n1`, `n2` ou noticias | Conteudo editorial do prototipo |
+| `preferencias` | Minhas preferencias sao editaveis? | `src/mocks/userProfile.js` | Perfil possui categorias, autores e topicos demonstrativos | Abrir Perfil | Preferencias nao sao editaveis nem persistidas nesta Sprint |
+| `sem-reserva-real` | Posso reservar ou renovar pelo assistente? | Contrato Sprint 1 | O assistente apenas orienta caminhos fechados | Consultar catalogo/perfil | Sem reserva, pre-reserva, renovacao oficial ou SIBI/PHL |
+| `fora-do-escopo` | Tenho outra duvida fora desta lista | Escopo funcional Sprint 1 | Fallback honesto sem inventar capacidade | Explorar catalogo | Sem chat aberto, IA real, backend real ou fonte oficial |
+
+## Decisoes de produto
+
+- A Sprint 1 usa 9 perguntas guiadas para ficar dentro do criterio de 8 a 10 perguntas.
+- As recomendacoes continuam usando apenas IDs canonicos `b1..b8`.
+- Preferencias permanecem demonstrativas; a edicao simples fica fora deste incremento por risco de sugerir persistencia real.
+- Feedback de Sofia/Claudia entra por GitHub Issues, com template dedicado.
+- Guard reforcado em `scripts/qa-guard.mjs` valida quantidade de perguntas, texto base, IDs de livros, motivo, fonte, limite e proxima acao.
+
+## Cobertura das issues
+
+- #46: matriz de perguntas guiadas registrada neste documento e no service `src/services/guidedAssistantService.js`.
+- #47: painel de perguntas guiadas previsto para Home desktop e mobile, sem chat aberto.
+- #48: cada resposta/recomendacao possui motivo, fonte/limite e proxima acao.
+- #49: disponibilidade mockada e ausencia de reserva real aparecem no texto base e nas respostas.
+- #50: pergunta `fora-do-escopo` define fallback honesto.
+- #53: contrato preservado por IDs canonicos e guard automatizado.
+- #54: preferencias definidas como demonstrativas nesta Sprint.

--- a/SIBiSC/docs/product/status_geral_e_pendencias_atuais.md
+++ b/SIBiSC/docs/product/status_geral_e_pendencias_atuais.md
@@ -1,0 +1,189 @@
+# Status Geral e Pendencias Atuais - SIBiSC/Feltrim Agents
+
+Data: 2026-05-19  
+Workspace: `C:\Users\Rafael Feltrim\Downloads\Web e Mobile - USP`  
+Repositorio: `Web_Mobile`  
+App: `Web_Mobile/SIBiSC`
+
+## 1. Base verificada nesta analise
+
+Checagens executadas em modo leitura no repositorio `Web_Mobile`:
+
+- `git status --short --branch`
+- `git branch --show-current`
+- `git branch -vv`
+- `git log --oneline --decorate --graph -12`
+- `git status --porcelain=v1 --untracked-files=all`
+- `git status --short --untracked-files=all -- portfolio`
+- `git ls-files -s portfolio`
+- `gh pr view 45` e `gh pr checks 45`
+- `gh pr view 55` e `gh pr checks 55`
+- `gh issue view 46..54`
+
+Documentos consultados:
+
+- `SIBiSC/docs/product/status_final_execucoes_pendentes.md`
+- `SIBiSC/docs/product/plano_execucao_sprint1_assistente_guiado.md`
+- `SIBiSC/docs/qa/sprint1_evidencias_validacao.md`
+- `SIBiSC/docs/product/review_pr45_sprint0.md`
+- `SIBiSC/docs/qa/review_pr55_sprint1.md`
+
+## 2. Estado atual do Git e GitHub
+
+- Branch atual local: `feature/sibisc-guided-assistant-sprint1`.
+- Branch atual rastreia `origin/feature/sibisc-guided-assistant-sprint1`.
+- HEAD atual: `f5a6796 feat(sibisc): implement guided assistant sprint 1`.
+- `dev` local esta em `c53d31e docs(sibisc): plan guided assistant sprint 1`, alinhada com `origin/dev`.
+- Antes deste relatorio, `git status --porcelain=v1 --untracked-files=all` nao listou arquivos pendentes.
+- `portfolio` nao apareceu no status do repositorio pai e nao apareceu em `git ls-files -s portfolio`.
+- `Test-Path portfolio` retornou `True`, indicando que a pasta/repo local preservado ainda existe, mas sem contaminar o status do `Web_Mobile`.
+- Este arquivo de relatorio e o unico novo artefato esperado apos a analise, enquanto nao houver commit/push autorizado.
+
+## 3. Entregue e concluido
+
+- Sprint 0 implementada, validada, revisada, corrigida, commitada, publicada em `dev` e promovida para `main`.
+- PR #45 de `dev` para `main` foi mesclado em 2026-05-19 (`MERGED`).
+- Conflitos do PR #45 foram resolvidos antes do merge.
+- Checks do PR #45 estavam verdes antes do merge:
+  - QA Gate / `P0 Repository Guard`: sucesso.
+  - QA Gate / `P1 Frontend Build`: sucesso.
+  - Vercel: sucesso.
+  - Netlify deploy preview: sucesso.
+  - Checks auxiliares Netlify de headers/pages/redirects apareceram como neutros/skipping, sem bloqueio observado.
+- Review de Sprint 0 documentada em `SIBiSC/docs/product/review_pr45_sprint0.md`.
+- Portfolio removido como gitlink quebrado do indice do `Web_Mobile`.
+- `portfolio/` preservado como repositorio local separado.
+- Documentos de produto, QA, branches, portfolio e sprints foram criados e publicados em `dev`.
+
+### Decisoes para Sprint 1
+
+- Escopo principal: assistente guiado.
+- Linguagem: manter linguagem existente do produto, com limites claros de prototipo.
+- Feedback Sofia/Claudia: GitHub Issues.
+- Disponibilidade: mock rotulado como dado de prototipo.
+- Modelo de trabalho: QA + Dev pairing obrigatorio por historia.
+
+### Sprint 1
+
+- Issues #46 a #54 foram criadas para a Sprint 1.
+- Sprint 1 foi implementada na branch `feature/sibisc-guided-assistant-sprint1`.
+- Commit publicado: `f5a6796 feat(sibisc): implement guided assistant sprint 1`.
+- PR #55 aberto de `feature/sibisc-guided-assistant-sprint1` para `dev`.
+- PR #55 esta `OPEN`, `MERGEABLE` e com `mergeStateStatus: CLEAN`.
+- Vercel do PR #55 esta verde.
+- Evidencias de validacao local da Sprint 1 foram registradas em `SIBiSC/docs/qa/sprint1_evidencias_validacao.md`.
+- Review complementar local do PR #55 foi registrada em `SIBiSC/docs/qa/review_pr55_sprint1.md`.
+- O documento de QA da Sprint 1 registra:
+  - painel com 9 perguntas fechadas;
+  - respostas com motivo, fonte/limite e proxima acao;
+  - disponibilidade mockada e ausencia de reserva real comunicadas;
+  - fallback honesto para fora de escopo;
+  - preferencias tratadas como demonstrativas;
+  - template de feedback Sofia/Claudia;
+  - guard reforcado para perguntas guiadas e IDs canonicos;
+  - `ReadLints`, `npm run qa:repo`, `npm run qa:ci` e smoke Playwright aprovados localmente.
+
+## 4. PRs e reviews atuais
+
+### PR #45 - `dev` -> `main`
+
+- Estado: `MERGED`.
+- Merged at: 2026-05-19T13:01:59Z.
+- Situacao: Sprint 0 promovida para `main`.
+
+### PR #55 - `feature/sibisc-guided-assistant-sprint1` -> `dev`
+
+- Estado: `OPEN`.
+- Mergeability: `MERGEABLE`.
+- Merge state: `CLEAN`.
+- Checks visiveis no momento:
+  - Vercel: sucesso.
+  - Vercel Preview Comments: sucesso.
+- QA Gate remoto nao apareceu no `statusCheckRollup` nem em `gh pr checks 55` no momento desta verificacao.
+- Review decision no GitHub: sem decisao formal preenchida no campo consultado.
+- Review local complementar: aprovado com ressalvas em `SIBiSC/docs/qa/review_pr55_sprint1.md`.
+- Situacao recomendada: GO para merge em `dev` com ressalvas de processo, desde que o time aceite a validacao local complementar para compensar o QA Gate remoto ausente e registre a triagem/fechamento manual das issues #46-#54 se necessario.
+
+## 5. Estado das issues #46-#54
+
+Todas as issues da Sprint 1 seguem `OPEN`, sem assignees e sem milestone observados na consulta.
+
+| Issue | Estado | Observacao |
+| --- | --- | --- |
+| #46 S1-01 Definir matriz de perguntas guiadas do Feltrim Agents | OPEN | Conteudo coberto no PR #55, mas issue ainda nao fechada. |
+| #47 S1-02 Implementar painel de assistente guiado | OPEN | Implementacao coberta no PR #55, pendente review/fechamento. |
+| #48 S1-03 Exibir motivo, fonte e proxima acao nas recomendacoes | OPEN | Evidencias registradas, pendente review/fechamento. |
+| #49 S1-04 Comunicar disponibilidade mockada e ausencia de reserva real | OPEN | Evidencias registradas, pendente review/fechamento. |
+| #50 S1-05 Criar fallback honesto para perguntas fora do escopo | OPEN | Evidencias registradas, pendente review/fechamento. |
+| #51 S1-06 Criar template de feedback Sofia/Claudia em GitHub Issues | OPEN | Template citado nas evidencias, pendente review/fechamento. |
+| #52 S1-07 Montar matriz QA dos 10 cenarios do assistente | OPEN | Matriz registrada em doc de QA, pendente review/fechamento. |
+| #53 S1-08 Preservar guards e contrato de dados na Sprint 1 | OPEN | Guard citado como reforcado, pendente review/fechamento. |
+| #54 S1-09 Decidir preferencias demonstrativas ou edicao simples | OPEN | Decisao atual: demonstrativas; edicao simples fica fora deste incremento. |
+
+## 6. Pendencias tecnicas imediatas
+
+1. Confirmar por que o QA Gate remoto nao aparece no PR #55. Possibilidades: workflow nao disparou para a branch/base, filtro de paths/branches, ou check ainda nao configurado para esse PR.
+2. Decidir se o PR #55 exige QA Gate remoto verde antes do merge ou se as evidencias locais complementares sao suficientes para este merge em `dev`.
+3. Atualizar ou fechar issues #46-#54 conforme criterio de aceite, preferencialmente registrando comentario de validacao porque o GitHub retornou `closingIssuesReferences: []` para o PR #55.
+4. Revalidar rapidamente o preview remoto se a decisao de produto exigir evidencia visual alem do smoke local.
+
+## 7. Pendencias de produto e decisao
+
+- Registrar que o PR #45 ja foi mesclado como marco final da Sprint 0.
+- Aprovar ou solicitar ajustes no comportamento do assistente guiado entregue no PR #55.
+- Confirmar se as preferencias permanecem apenas demonstrativas no MVP ou se viram edicao simples em Sprint futura.
+- Definir politica operacional para fechamento das issues da Sprint 1: fechar no merge, fechar apos review de QA, ou manter abertas ate validacao Sofia/Claudia.
+- Definir se Sofia/Claudia ja devem usar o template de feedback em piloto interno.
+- Definir escopo de Sprint 2 somente depois da decisao sobre PR #55 e fechamento/triagem das issues #46-#54.
+
+## 8. Pendencias de QA, acessibilidade e performance
+
+- Executar ou registrar validacao com leitor de tela real antes de release, pois o documento de Sprint 1 marca isso como pendente.
+- Anexar prints ou video curto da Sprint 1 se o time exigir evidencia visual para review.
+- Confirmar QA Gate remoto do PR #55 ou registrar decisao explicita aceitando apenas a validacao local por enquanto.
+- Revalidar smoke principal em preview remoto antes de merge do PR #55:
+  - Home/Feltrim Agents;
+  - pergunta guiada;
+  - recomendacao;
+  - detalhe de livro;
+  - perfil/preferencias demonstrativas;
+  - fallback fora do escopo;
+  - fluxo mobile.
+- Performance/Lighthouse nao apareceu como check atual do PR #55 nesta consulta. Se for gate de release, rodar antes de promover Sprint 1 para `main`.
+
+## 9. Pendencias de Git, branches e portfolio
+
+- Branch atual e `feature/sibisc-guided-assistant-sprint1`, nao `dev`.
+- PR #45 ja foi mesclado; o merge do PR #55 em `dev` nao altera mais o escopo de um PR aberto de Sprint 0 para `main`.
+- `portfolio` existe localmente, nao aparece no status do repo pai e nao esta mais listado como entrada versionada pelo `Web_Mobile`.
+- Nao ha recomendacao de apagar `portfolio`, limpar branches ou rodar prune sem decisao explicita do Rafael.
+- Este relatorio e `SIBiSC/docs/qa/review_pr55_sprint1.md` permanecem como artefatos locais pendentes de versionamento ate haver decisao de commit.
+
+## 10. Proxima ordem recomendada de execucao
+
+1. Registrar que PR #45 ja foi mesclado e que Sprint 0 esta promovida para `main`.
+2. Decidir formalmente sobre aceitar a validacao local complementar do PR #55 enquanto o QA Gate remoto nao aparece.
+3. Atualizar as issues #46-#54 com comentario de evidencia e fechar as que forem aceitas.
+4. Mesclar PR #55 em `dev` se Rafael aprovar o GO com ressalvas.
+5. Criar novo PR de promocao de `dev` para `main` para Sprint 1, se esse for o fluxo de release.
+6. Planejar Sprint 2 apenas depois de consolidar Sprint 1 e registrar Go/No-Go.
+
+## 11. Go/No-Go
+
+### PR #45
+
+MERGED em `main`.
+
+Justificativa: PR #45 foi mesclado em 2026-05-19 apos validacao e checks verdes.
+
+### PR #55
+
+GO com ressalvas para merge em `dev`.
+
+Justificativa: PR esta `MERGEABLE`, Vercel verde, `npm run qa:repo`, `npm run qa:ci` e smoke Playwright local passaram. A ressalva e que o QA Gate remoto nao apareceu e as issues #46-#54 seguem abertas, podendo exigir triagem/fechamento manual.
+
+### Sprint 2
+
+NO-GO para iniciar implementacao.
+
+Justificativa: Sprint 2 ainda depende de revisar/mesclar Sprint 1, resolver a situacao das issues #46-#54, confirmar QA/acessibilidade pendente e registrar decisoes de produto para o proximo incremento.

--- a/SIBiSC/docs/qa/review_pr55_sprint1.md
+++ b/SIBiSC/docs/qa/review_pr55_sprint1.md
@@ -1,0 +1,77 @@
+# Review PR #55 - Sprint 1 SIBiSC/Feltrim Agents
+
+Data: 2026-05-19  
+PR: [#55](https://github.com/RaFeltrim/sibisc-hub-cultural/pull/55)  
+Base: `dev`  
+Head: `feature/sibisc-guided-assistant-sprint1`  
+Escopo: revisao local complementar antes de qualquer merge, porque o QA Gate remoto nao apareceu no PR.
+
+## Veredito
+
+**Aprovado com ressalvas.**
+
+Nao encontrei bug funcional bloqueante no assistente guiado, nos dados locais/mock, nos textos de limite, na navegacao por teclado basica, na responsividade da Home desktop/mobile, no `qa-guard`, na documentacao ou no template Sofia/Claudia.
+
+Recomendacao Go/No-Go: **GO para merge em `dev` com ressalvas de processo**, desde que o time aceite a validacao local como compensacao temporaria para o QA Gate remoto ausente e registre o fechamento/triagem manual das issues #46-#54. Nao foi feito commit, push ou merge nesta revisao.
+
+## Achados por severidade
+
+### Bloqueantes / P0
+
+- Nenhum achado.
+
+### Altos / P1
+
+- Nenhum achado.
+
+### Medios / P2
+
+- Nenhum achado funcional. O comportamento entregue ficou dentro do contrato de Sprint 1: assistente guiado fechado, sem chat aberto, sem IA/backend real, sem reserva/renovacao oficial e sem disponibilidade oficial.
+
+### Baixos / P3 e ressalvas
+
+- **QA Gate remoto ausente no PR #55.** O `statusCheckRollup` do PR mostra Vercel verde, mas nao mostra o QA Gate remoto. A validacao local passou, porem ainda recomendo investigar o workflow em tarefa separada ou registrar decisao explicita aceitando QA local para este merge.
+- **Issues #46-#54 seguem abertas.** O corpo do PR contem `Closes #46` a `Closes #54`, mas a consulta do GitHub retornou `closingIssuesReferences: []`. Como o PR mira `dev`, pode ser necessario fechar ou comentar as issues manualmente apos o merge/aceite.
+- **Leitor de tela real ainda pendente.** A estrutura possui `aria-live`, `aria-pressed`, foco visivel e `role="status"`, mas a validacao com NVDA/VoiceOver/Leitor real nao foi executada nesta rodada.
+
+## Revisao do diff
+
+- **Comportamento do assistente guiado:** o PR adiciona 9 perguntas fechadas, fallback honesto e respostas com motivo, fonte/limite e proxima acao. O smoke confirmou troca de pergunta e resposta de fallback sem inventar capacidades.
+- **Dados locais/mock:** `guidedAssistantService.js` deriva livros, eventos, noticias e perfil apenas de mocks locais e valida IDs canonicos via `qa-guard`.
+- **Texto de limites:** os textos declaram dados locais do prototipo, disponibilidade mockada, ausencia de reserva real e ausencia de backend/IA/integracao oficial onde isso importa.
+- **Acessibilidade:** Home desktop e mobile usam botoes com `aria-pressed`, `aria-controls`, resposta em `aria-live="polite"`/`aria-atomic`, foco visivel em botoes/links e `SearchField` com `role="status"`.
+- **Responsividade:** smoke mobile em 375x812 confirmou `/home-mobile` sem overflow horizontal (`scrollWidth` igual a `innerWidth`).
+- **`qa-guard` e docs/evidencias:** guard passou e cobre perguntas guiadas, texto base, IDs canonicos, motivos, fontes, limites e proximas acoes. Docs da matriz e evidencias Sprint 1 estao coerentes com o incremento.
+- **Template Sofia/Claudia:** `.github/ISSUE_TEMPLATE/feedback_sofia_claudia.md` cobre relato, reproducao, evidencias, severidade, prioridade, status e criterio de fechamento.
+
+## Testes rodados
+
+- `npm run qa:repo` em `SIBiSC`: aprovado.
+- `npm run qa:ci` em `SIBiSC`: aprovado, incluindo `vite build` com 83 modulos transformados.
+- Smoke Playwright CLI em servidor local temporario:
+  - `/`: abriu Home e confirmou Feltrim Agents, 9 perguntas guiadas, `aria-pressed` e resposta explicavel.
+  - Fallback: acionado "Fora do escopo", com texto sem chat aberto, IA generativa, catalogo oficial em tempo real ou integracao com atendimento.
+  - Busca assistida: termo `vidas` retornou status com 1 sugestao local e link para `Vidas Secas`.
+  - `/catalogo/b7`: detalhe abriu com disponibilidade mockada por unidade.
+  - `/perfil`: perfil abriu com preferencias demonstrativas.
+  - `/home-mobile` em 375x812: sem overflow horizontal detectado.
+  - Console Playwright: 0 warnings e 0 errors.
+- `ReadLints`: executado nos arquivos alterados pelo PR #55 e nos relatorios tocados nesta revisao; sem erros reportados.
+
+## Relacao com issues #46-#54
+
+- #46 `S1-01 Definir matriz de perguntas guiadas do Feltrim Agents`: coberta por `docs/product/matriz_perguntas_guiadas_sprint1.md` e `guidedAssistantService.js`; issue ainda `OPEN`.
+- #47 `S1-02 Implementar painel de assistente guiado`: coberta nas Homes desktop/mobile; issue ainda `OPEN`.
+- #48 `S1-03 Exibir motivo, fonte e proxima acao nas recomendacoes`: coberta nos cards de resposta/recomendacao; issue ainda `OPEN`.
+- #49 `S1-04 Comunicar disponibilidade mockada e ausencia de reserva real`: coberta no texto base e nas respostas; issue ainda `OPEN`.
+- #50 `S1-05 Criar fallback honesto para perguntas fora do escopo`: coberta pela pergunta `fora-do-escopo`; issue ainda `OPEN`.
+- #51 `S1-06 Criar template de feedback Sofia/Claudia em GitHub Issues`: coberta pelo template dedicado; issue ainda `OPEN`.
+- #52 `S1-07 Montar matriz QA dos 10 cenarios do assistente`: coberta por `docs/qa/sprint1_evidencias_validacao.md` e por esta revisao complementar; issue ainda `OPEN`.
+- #53 `S1-08 Preservar guards e contrato de dados na Sprint 1`: coberta pelo `qa-guard` reforcado; issue ainda `OPEN`.
+- #54 `S1-09 Decidir preferencias demonstrativas ou edicao simples`: coberta pela decisao de manter preferencias demonstrativas nesta Sprint; issue ainda `OPEN`.
+
+## Recomendacao final
+
+**Merge recomendado em `dev`: sim, com ressalvas.**
+
+Antes ou logo apos o merge, recomendo registrar no PR/issues que o QA Gate remoto nao apareceu, que a decisao foi aceitar a validacao local complementar, e que as issues #46-#54 precisam de fechamento/triagem manual se o GitHub nao as fechar automaticamente.

--- a/SIBiSC/docs/qa/sprint1_evidencias_validacao.md
+++ b/SIBiSC/docs/qa/sprint1_evidencias_validacao.md
@@ -1,0 +1,65 @@
+# Evidencias de Validacao - Sprint 1 SIBiSC/Feltrim Agents
+
+Data: 2026-05-19  
+Branch: `feature/sibisc-guided-assistant-sprint1`  
+Escopo inicial: P0/P1 essenciais do assistente guiado.
+
+## 1. Resumo QA + Dev
+
+Status inicial: validacao automatizada aprovada e smoke Playwright aprovado nos fluxos principais do assistente guiado.
+
+Incrementos cobertos:
+
+- Painel de assistente guiado com 9 perguntas fechadas, sem chat aberto.
+- Respostas com motivo, fonte/limite e proxima acao.
+- Comunicacao explicita de dados locais do prototipo, disponibilidade mockada e ausencia de reserva real.
+- Fallback honesto para pergunta fora do escopo.
+- Preferencias tratadas como demonstrativas; edicao simples fica fora deste incremento.
+- Template de GitHub Issue para feedback Sofia/Claudia.
+- Guard de repositorio reforcado para validar perguntas guiadas e IDs canonicos.
+
+## 2. Matriz QA dos 10 cenarios
+
+| Caso | Issue | Passos | Esperado | Status inicial |
+| --- | --- | --- | --- | --- |
+| 1. Entender assistente em ate 1 minuto | #47 | Abrir `/` e ler hero/painel | Usuario entende assistente guiado, dados locais e limites | Aprovado no smoke |
+| 2. Selecionar pergunta de literatura | #46 #47 #48 | Em `/`, acionar "Literatura brasileira" | Resposta mostra `b7`/`b3`, motivo, fonte/limite e proxima acao | Aprovado por guard e smoke do painel |
+| 3. Selecionar pergunta por autor | #46 #48 | Acionar "Machado de Assis" | Resposta aponta `b3`/`b1`, sem IDs inexistentes | Aprovado por guard |
+| 4. Tema cidade e sociedade | #46 #48 | Acionar "Cidade e sociedade" | Resposta aponta `b2`/`b5` com motivo especifico | Aprovado no smoke |
+| 5. Disponibilidade mockada | #49 | Acionar "Disponibilidade" | Texto declara dados locais, disponibilidade nao oficial e sem reserva real | Aprovado no smoke |
+| 6. Eventos e noticias | #46 #48 | Acionar "Eventos de leitura" e "Noticias e servicos" | Referencias possuem motivo, fonte/limite e links validos | Aprovado por guard |
+| 7. Preferencias demonstrativas | #54 | Acionar "Preferencias" e abrir `/perfil` | UI declara preferencias demonstrativas e sem persistencia real | Aprovado no smoke de Perfil |
+| 8. Fallback honesto | #50 | Acionar "Fora do escopo" | Resposta nao inventa IA, backend, SIBI/PHL, horario, reserva ou fonte oficial | Aprovado no smoke |
+| 9. Mobile e touch | #47 #52 | Abrir `/home-mobile`, acionar perguntas | Painel permanece responsivo, sem scroll horizontal e com area touch adequada | Aprovado no smoke mobile 375x812 |
+| 10. Teclado, foco e aria-live | #47 #52 | Navegar por Tab/Enter nas perguntas | Foco visivel, botoes com `aria-pressed`, resposta em regiao `aria-live` | Aprovado por estrutura e smoke automatizado; leitor de tela real pendente |
+
+## 3. Comandos planejados
+
+Executar a partir de `Web_Mobile/SIBiSC`:
+
+| Comando/validacao | Resultado obtido |
+| --- | --- |
+| `ReadLints` nos arquivos editados | Aprovado, sem erros reportados |
+| `npm run qa:repo` | Aprovado; guard validou estrutura, docs, rotas, IDs canonicos e perguntas guiadas |
+| `npm run qa:ci` | Aprovado; `qa:repo` + `vite build`, 83 modulos transformados |
+| Smoke Home/Feltrim Agents, Catalogo, Detalhe e Perfil | Aprovado via Playwright CLI em `http://127.0.0.1:5177/` |
+| Smoke `/home-mobile` | Aprovado via Playwright CLI, viewport 375x812, sem overflow horizontal detectado |
+
+Observacao: uma primeira tentativa de smoke com `node -e` falhou por quoting do PowerShell antes de abrir o app. A validacao foi reexecutada com `playwright-cli open` + `playwright-cli run-code --filename` e passou.
+
+## 4. Evidencia por issue
+
+- #46: `docs/product/matriz_perguntas_guiadas_sprint1.md` e `src/services/guidedAssistantService.js`.
+- #47: painel de perguntas em `HomePage.jsx` e `HomePageMobile.jsx`.
+- #48: cards de resposta/recomendacao exibem motivo, fonte/limite e proxima acao.
+- #49: texto base e respostas comunicam disponibilidade mockada e ausencia de reserva real.
+- #50: pergunta `fora-do-escopo` implementa fallback honesto.
+- #51: `.github/ISSUE_TEMPLATE/feedback_sofia_claudia.md`.
+- #52: matriz QA dos 10 cenarios neste documento.
+- #53: `scripts/qa-guard.mjs` valida perguntas guiadas e contrato de IDs.
+- #54: preferencias documentadas e comunicadas como demonstrativas.
+
+## 5. Pendencias ate o fechamento
+
+- Teste com leitor de tela real ainda recomendado antes de release.
+- Anexar prints ou video curto se o time exigir evidencia visual para review.

--- a/SIBiSC/scripts/qa-guard.mjs
+++ b/SIBiSC/scripts/qa-guard.mjs
@@ -81,6 +81,7 @@ const [
   { mockLoans, mockLoanHistory, mockFavorites },
   { mockHomeContent },
   { getRecommendations },
+  { guidedAssistantQuestions, GUIDED_ASSISTANT_LIMIT_NOTICE },
   { eventItems },
   { newsItems },
   { units },
@@ -89,6 +90,7 @@ const [
   importProjectModule('src/mocks/userProfile.js'),
   importProjectModule('src/mocks/homePageMobileData.js'),
   importProjectModule('src/services/userProfileService.js'),
+  importProjectModule('src/services/guidedAssistantService.js'),
   importProjectModule('src/mocks/events.js'),
   importProjectModule('src/mocks/news.js'),
   importProjectModule('src/mocks/units.js'),
@@ -252,6 +254,55 @@ for (const recommendation of recommendations) {
   }
   if (recommendation.source !== 'catalogo-mock') {
     failures.push(`recomendacao ${recommendation.id} sem source catalogo-mock`);
+  }
+}
+
+if (guidedAssistantQuestions.length < 8 || guidedAssistantQuestions.length > 10) {
+  failures.push(`assistente guiado deve ter de 8 a 10 perguntas, encontrado: ${guidedAssistantQuestions.length}`);
+}
+
+if (
+  !GUIDED_ASSISTANT_LIMIT_NOTICE.includes('dados locais do prototipo') ||
+  !GUIDED_ASSISTANT_LIMIT_NOTICE.includes('nao ha reserva real')
+) {
+  failures.push('texto base do assistente guiado deve declarar dados locais do prototipo e ausencia de reserva real');
+}
+
+for (const question of guidedAssistantQuestions) {
+  for (const field of ['id', 'label', 'shortLabel', 'category', 'answer']) {
+    if (!question[field]) {
+      failures.push(`pergunta guiada sem campo obrigatorio: ${question.id ?? '(sem id)'} -> ${field}`);
+    }
+  }
+
+  if (!question.answer?.source || !question.answer?.limit || !question.answer?.nextAction?.to) {
+    failures.push(`pergunta guiada ${question.id} sem fonte, limite ou proxima acao`);
+  }
+
+  const questionRecommendations = question.answer?.recommendations ?? [];
+  for (const item of questionRecommendations) {
+    assertKnownBookId('pergunta guiada', question.id, item.bookId);
+    const catalogBook = catalogById.get(item.bookId);
+
+    if (!catalogBook) continue;
+
+    const availability = getAvailability(catalogBook);
+    if (item.id !== item.bookId) {
+      failures.push(`pergunta guiada ${question.id} deve manter id igual ao bookId em ${item.bookId}`);
+    }
+    if (item.availableCount !== availability.availableCount || item.totalCount !== availability.totalCount) {
+      failures.push(`pergunta guiada ${question.id} tem disponibilidade divergente do catalogo em ${item.bookId}`);
+    }
+    if (!item.reason || !item.source || !item.limit || !item.nextAction?.to?.includes(item.bookId)) {
+      failures.push(`pergunta guiada ${question.id} tem recomendacao sem motivo, fonte, limite ou rota valida`);
+    }
+  }
+
+  const references = question.answer?.references ?? [];
+  for (const reference of references) {
+    if (!reference.reason || !reference.source || !reference.limit || !reference.nextAction?.to) {
+      failures.push(`pergunta guiada ${question.id} tem referencia sem motivo, fonte, limite ou rota`);
+    }
   }
 }
 

--- a/SIBiSC/src/pages/HomePage.jsx
+++ b/SIBiSC/src/pages/HomePage.jsx
@@ -11,6 +11,11 @@ import { getNews } from '../services/newsService';
 import { getEvents } from '../services/eventsService';
 import { searchBooks } from '../services/catalogService';
 import { getRecommendations, getUserProfile } from '../services/userProfileService';
+import {
+  GUIDED_ASSISTANT_LIMIT_NOTICE,
+  getGuidedAssistantQuestion,
+  guidedAssistantQuestions,
+} from '../services/guidedAssistantService';
 import useDebouncedValue from '../hooks/useDebouncedValue';
 import styles from './HomePage.module.css';
 
@@ -38,12 +43,6 @@ const assistantCapabilities = [
   },
 ];
 
-const assistantGuides = [
-  { to: '/catalogo', label: 'Buscar livros por tema, autor ou ISBN' },
-  { to: '/eventos', label: 'Encontrar eventos ligados ao seu perfil' },
-  { to: '/noticias', label: 'Entender novidades da rede de bibliotecas' },
-];
-
 function getQuickMatches(books, searchTerm) {
   const normalizedTerm = searchTerm.trim().toLowerCase();
 
@@ -67,6 +66,7 @@ function HomePage() {
   const [assistantRecommendations, setAssistantRecommendations] = useState([]);
   const [query, setQuery] = useState('');
   const [searchStatus, setSearchStatus] = useState('');
+  const [selectedGuideId, setSelectedGuideId] = useState(guidedAssistantQuestions[0].id);
   const debouncedQuery = useDebouncedValue(query, 180);
 
   useEffect(() => {
@@ -113,6 +113,8 @@ function HomePage() {
   const quickMatches = useMemo(() => {
     return getQuickMatches(catalogBooks, debouncedQuery);
   }, [catalogBooks, debouncedQuery]);
+
+  const selectedGuide = useMemo(() => getGuidedAssistantQuestion(selectedGuideId), [selectedGuideId]);
 
   const assistantMetrics = [
     { value: profile?.readingPreferences.categories.length ?? 0, label: 'interesses' },
@@ -230,13 +232,75 @@ function HomePage() {
             />
 
             <div className={styles.guideList} aria-label="Perguntas que o Feltrim Agents orienta nesta versão">
-              <strong>Posso ajudar você a</strong>
-              {assistantGuides.map((guide) => (
-                <Link key={guide.to} to={guide.to} className={styles.guideLink}>
-                  {guide.label}
-                </Link>
-              ))}
+              <strong>Perguntas guiadas</strong>
+              <div className={styles.guideButtons} role="list">
+                {guidedAssistantQuestions.map((guide) => (
+                  <button
+                    key={guide.id}
+                    type="button"
+                    className={styles.guideButton}
+                    aria-pressed={guide.id === selectedGuideId}
+                    aria-controls="guided-assistant-answer"
+                    onClick={() => setSelectedGuideId(guide.id)}
+                  >
+                    <span>{guide.shortLabel}</span>
+                    <em>{guide.category}</em>
+                  </button>
+                ))}
+              </div>
             </div>
+
+            <section
+              id="guided-assistant-answer"
+              className={styles.guidedAnswer}
+              aria-live="polite"
+              aria-atomic="true"
+              aria-labelledby="guided-answer-title"
+            >
+              <span className={styles.answerCategory}>{selectedGuide.category}</span>
+              <h2 id="guided-answer-title">{selectedGuide.answer.title}</h2>
+              <p>{selectedGuide.answer.summary}</p>
+
+              {selectedGuide.answer.recommendations?.length ? (
+                <div className={styles.answerItems} aria-label="Recomendações explicáveis">
+                  {selectedGuide.answer.recommendations.map((item) => (
+                    <Link key={item.id} className={styles.answerItem} to={item.nextAction.to}>
+                      <strong>{item.title}</strong>
+                      <span>Motivo: {item.reason}</span>
+                      <span>
+                        Fonte/limite: {item.source}; {item.limit}
+                      </span>
+                      <em>
+                        Próxima ação: {item.nextAction.label}. {item.availableCount} de {item.totalCount} exemplares
+                        no inventário local.
+                      </em>
+                    </Link>
+                  ))}
+                </div>
+              ) : null}
+
+              {selectedGuide.answer.references?.length ? (
+                <div className={styles.answerItems} aria-label="Referências locais explicáveis">
+                  {selectedGuide.answer.references.map((item) => (
+                    <Link key={item.id} className={styles.answerItem} to={item.nextAction.to}>
+                      <strong>{item.title}</strong>
+                      <span>Motivo: {item.reason}</span>
+                      <span>
+                        Fonte/limite: {item.source}; {item.limit}
+                      </span>
+                      <em>Próxima ação: {item.nextAction.label}</em>
+                    </Link>
+                  ))}
+                </div>
+              ) : null}
+
+              <p className={styles.limitNotice}>
+                <strong>Fonte/limite:</strong> {selectedGuide.answer.source}. {selectedGuide.answer.limit}
+              </p>
+              <Link className={styles.answerAction} to={selectedGuide.answer.nextAction.to}>
+                {selectedGuide.answer.nextAction.label}
+              </Link>
+            </section>
 
             {query.trim() ? (
               <div className={styles.quickResults}>
@@ -261,12 +325,18 @@ function HomePage() {
                   Sugestões baseadas nas preferências cadastradas de {profile?.name.split(' ')[0] ?? 'leitor'}{' '}
                   e na disponibilidade mockada do acervo. Não há backend de IA ou reserva real nesta prévia.
                 </p>
+                <p className={styles.limitNotice}>{GUIDED_ASSISTANT_LIMIT_NOTICE}</p>
                 <div className={styles.recommendationList}>
                   {assistantRecommendations.map((book) => (
                     <Link key={book.id} className={styles.recommendationItem} to={`/catalogo/${book.bookId}`}>
                       <strong>{book.title}</strong>
-                      <span>{book.reason}</span>
-                      <em>{book.availableCount} exemplares disponíveis no catálogo local</em>
+                      <span>Motivo: {book.reason}</span>
+                      <span>
+                        Fonte/limite: {book.source}; disponibilidade mockada do catálogo local, sem reserva real.
+                      </span>
+                      <em>
+                        Próxima ação: abrir detalhe. {book.availableCount} exemplares disponíveis no catálogo local.
+                      </em>
                     </Link>
                   ))}
                 </div>

--- a/SIBiSC/src/pages/HomePage.module.css
+++ b/SIBiSC/src/pages/HomePage.module.css
@@ -455,6 +455,61 @@
   font-size: 0.84rem;
 }
 
+.guideButtons {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.guideButton {
+  display: grid;
+  gap: 0.16rem;
+  min-height: 3.25rem;
+  padding: 0.62rem 0.7rem;
+  border: 0;
+  border-radius: var(--radius-sm);
+  color: var(--color-ink);
+  background: rgba(255, 255, 255, 0.62);
+  box-shadow: inset 0 0 0 1px rgba(18, 38, 63, 0.08);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.guideButton span {
+  color: var(--color-ink);
+  font-size: 0.82rem;
+  font-weight: 800;
+  line-height: 1.25;
+}
+
+.guideButton em {
+  color: var(--color-ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-style: normal;
+  text-transform: uppercase;
+}
+
+.guideButton:hover,
+.guideButton:focus-visible,
+.guideButton[aria-pressed='true'] {
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow:
+    inset 0 0 0 1px rgba(210, 100, 56, 0.24),
+    0 10px 24px rgba(18, 38, 63, 0.08);
+  transform: translateY(-1px);
+}
+
+.guideButton:focus-visible {
+  outline: 3px solid rgba(210, 100, 56, 0.3);
+  outline-offset: 3px;
+}
+
 .guideLink {
   color: var(--color-accent-strong);
   font-size: 0.86rem;
@@ -463,6 +518,122 @@
 
 .guideLink:focus-visible {
   border-radius: 0.25rem;
+  outline: 3px solid rgba(210, 100, 56, 0.3);
+  outline-offset: 3px;
+}
+
+.guidedAnswer {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: var(--radius-sm);
+  background: rgba(18, 38, 63, 0.07);
+  box-shadow: inset 0 0 0 1px rgba(18, 38, 63, 0.08);
+}
+
+.answerCategory {
+  width: fit-content;
+  padding: 0.32rem 0.58rem;
+  border-radius: var(--radius-pill);
+  color: var(--color-accent-strong);
+  background: rgba(210, 100, 56, 0.12);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.guidedAnswer h2 {
+  color: var(--color-ink);
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  letter-spacing: -0.02em;
+}
+
+.guidedAnswer p {
+  color: var(--color-ink-soft);
+  font-size: 0.9rem;
+}
+
+.answerItems {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.answerItem {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.78rem 0.85rem;
+  border-radius: var(--radius-sm);
+  color: var(--color-ink);
+  background: rgba(255, 255, 255, 0.68);
+  box-shadow: inset 0 0 0 1px rgba(18, 38, 63, 0.08);
+  transition:
+    background-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.answerItem:hover,
+.answerItem:focus-visible {
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow:
+    inset 0 0 0 1px rgba(210, 100, 56, 0.18),
+    0 12px 28px rgba(18, 38, 63, 0.08);
+  transform: translateY(-2px);
+}
+
+.answerItem:focus-visible {
+  outline: 3px solid rgba(210, 100, 56, 0.3);
+  outline-offset: 3px;
+}
+
+.answerItem span,
+.answerItem em {
+  color: var(--color-ink-soft);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.answerItem em {
+  color: var(--color-accent-strong);
+  font-family: var(--font-mono);
+  font-style: normal;
+}
+
+.limitNotice {
+  padding: 0.68rem 0.75rem;
+  border-radius: var(--radius-sm);
+  color: var(--color-ink-soft);
+  background: rgba(255, 255, 255, 0.54);
+  box-shadow: inset 0 0 0 1px rgba(18, 38, 63, 0.08);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.limitNotice strong {
+  color: var(--color-ink);
+}
+
+.answerAction {
+  justify-self: start;
+  padding: 0.62rem 0.85rem;
+  border-radius: var(--radius-pill);
+  color: white;
+  background: var(--color-accent-strong);
+  font-size: 0.84rem;
+  font-weight: 800;
+  transition:
+    background-color 180ms ease,
+    transform 180ms ease;
+}
+
+.answerAction:hover,
+.answerAction:focus-visible {
+  background: var(--color-accent);
+  transform: translateY(-1px);
+}
+
+.answerAction:focus-visible {
   outline: 3px solid rgba(210, 100, 56, 0.3);
   outline-offset: 3px;
 }
@@ -634,6 +805,10 @@
     grid-template-columns: auto 1fr;
   }
 
+  .guideButtons {
+    grid-template-columns: 1fr;
+  }
+
   .pipelineItem em {
     grid-column: auto;
   }
@@ -658,6 +833,9 @@
   .commandLink::after,
   .quickResult,
   .guideLink,
+  .guideButton,
+  .answerItem,
+  .answerAction,
   .quickResult::before,
   .recommendationItem,
   .console,
@@ -670,6 +848,13 @@
   .commandLink:focus-visible,
   .quickResult:hover,
   .quickResult:focus-visible,
+  .guideButton:hover,
+  .guideButton:focus-visible,
+  .guideButton[aria-pressed='true'],
+  .answerItem:hover,
+  .answerItem:focus-visible,
+  .answerAction:hover,
+  .answerAction:focus-visible,
   .recommendationItem:hover,
   .recommendationItem:focus-visible,
   .console:hover,

--- a/SIBiSC/src/pages/HomePageMobile.jsx
+++ b/SIBiSC/src/pages/HomePageMobile.jsx
@@ -14,12 +14,11 @@ import { getNews } from '../services/newsService';
 import { getEvents } from '../services/eventsService';
 import { searchBooks } from '../services/catalogService';
 import { getUserProfile } from '../services/userProfileService';
-
-const assistantGuides = [
-  { to: '/catalogo', label: 'livros por interesse' },
-  { to: '/eventos', label: 'agenda cultural' },
-  { to: '/noticias', label: 'notícias da rede' },
-];
+import {
+  GUIDED_ASSISTANT_LIMIT_NOTICE,
+  getGuidedAssistantQuestion,
+  guidedAssistantQuestions,
+} from '../services/guidedAssistantService';
 
 function getQuickMatches(books, searchTerm) {
   const normalizedTerm = searchTerm.trim().toLowerCase();
@@ -44,6 +43,7 @@ function HomePageMobile() {
   const [profile, setProfile] = useState(null);
   const [query, setQuery] = useState('');
   const [searchStatus, setSearchStatus] = useState('');
+  const [selectedGuideId, setSelectedGuideId] = useState(guidedAssistantQuestions[0].id);
   const debouncedQuery = useDebouncedValue(query, 180);
 
   useEffect(() => {
@@ -90,6 +90,8 @@ function HomePageMobile() {
     return getQuickMatches(catalogBooks, debouncedQuery);
   }, [catalogBooks, debouncedQuery]);
 
+  const selectedGuide = useMemo(() => getGuidedAssistantQuestion(selectedGuideId), [selectedGuideId]);
+
   function handleAssistantSearch() {
     const term = query.trim();
 
@@ -130,16 +132,79 @@ function HomePageMobile() {
 
         <div className={styles.assistantPreview}>
           <strong>Preferências usadas nas sugestões</strong>
-          <span>{profile?.readingPreferences.categories.join(' · ') ?? 'Carregando preferências do perfil...'}</span>
+          <span>
+            {profile?.readingPreferences.categories.join(' · ') ?? 'Carregando preferências do perfil...'}.
+            Preferências demonstrativas, sem edição persistida nesta versão.
+          </span>
         </div>
 
-        <div className={styles.assistantGuides} aria-label="Ajudas disponíveis no Feltrim Agents">
-          {assistantGuides.map((guide) => (
-            <Link key={guide.to} to={guide.to}>
-              {guide.label}
-            </Link>
+        <div className={styles.assistantGuides} aria-label="Perguntas guiadas do Feltrim Agents">
+          {guidedAssistantQuestions.map((guide) => (
+            <button
+              key={guide.id}
+              type="button"
+              aria-pressed={guide.id === selectedGuideId}
+              aria-controls="mobile-guided-assistant-answer"
+              onClick={() => setSelectedGuideId(guide.id)}
+            >
+              <span>{guide.shortLabel}</span>
+              <em>{guide.category}</em>
+            </button>
           ))}
         </div>
+
+        <section
+          id="mobile-guided-assistant-answer"
+          className={styles.guidedAnswer}
+          aria-live="polite"
+          aria-atomic="true"
+          aria-labelledby="mobile-guided-answer-title"
+        >
+          <span className={styles.answerCategory}>{selectedGuide.category}</span>
+          <h2 id="mobile-guided-answer-title">{selectedGuide.answer.title}</h2>
+          <p>{selectedGuide.answer.summary}</p>
+
+          {selectedGuide.answer.recommendations?.length ? (
+            <div className={styles.answerItems} aria-label="Recomendações explicáveis">
+              {selectedGuide.answer.recommendations.map((item) => (
+                <Link key={item.id} className={styles.answerItem} to={item.nextAction.to}>
+                  <strong>{item.title}</strong>
+                  <span>Motivo: {item.reason}</span>
+                  <span>
+                    Fonte/limite: {item.source}; {item.limit}
+                  </span>
+                  <em>
+                    Próxima ação: {item.nextAction.label}. {item.availableCount} de {item.totalCount} exemplares
+                    no inventário local.
+                  </em>
+                </Link>
+              ))}
+            </div>
+          ) : null}
+
+          {selectedGuide.answer.references?.length ? (
+            <div className={styles.answerItems} aria-label="Referências locais explicáveis">
+              {selectedGuide.answer.references.map((item) => (
+                <Link key={item.id} className={styles.answerItem} to={item.nextAction.to}>
+                  <strong>{item.title}</strong>
+                  <span>Motivo: {item.reason}</span>
+                  <span>
+                    Fonte/limite: {item.source}; {item.limit}
+                  </span>
+                  <em>Próxima ação: {item.nextAction.label}</em>
+                </Link>
+              ))}
+            </div>
+          ) : null}
+
+          <p className={styles.limitNotice}>
+            <strong>Fonte/limite:</strong> {selectedGuide.answer.source}. {selectedGuide.answer.limit}
+          </p>
+          <p className={styles.limitNotice}>{GUIDED_ASSISTANT_LIMIT_NOTICE}</p>
+          <Link className={styles.answerAction} to={selectedGuide.answer.nextAction.to}>
+            {selectedGuide.answer.nextAction.label}
+          </Link>
+        </section>
 
         <SearchField
           label="Busca assistida"

--- a/SIBiSC/src/pages/HomePageMobile.module.css
+++ b/SIBiSC/src/pages/HomePageMobile.module.css
@@ -52,23 +52,143 @@
 }
 
 .assistantGuides {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.45rem;
 }
 
-.assistantGuides a {
+.assistantGuides button {
+  display: grid;
+  gap: 0.16rem;
   min-height: 2.2rem;
   padding: 0.55rem 0.75rem;
+  border: 0;
   border-radius: var(--radius-pill);
   color: var(--color-accent-strong);
   background: rgba(255, 255, 255, 0.62);
   box-shadow: inset 0 0 0 1px rgba(16, 37, 63, 0.08);
-  font-size: 0.78rem;
-  font-weight: 700;
+  font: inherit;
+  text-align: left;
 }
 
-.assistantGuides a:focus-visible {
+.assistantGuides button[aria-pressed='true'] {
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(210, 100, 56, 0.28);
+}
+
+.assistantGuides span {
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.assistantGuides em {
+  color: var(--color-ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  font-style: normal;
+  text-transform: uppercase;
+}
+
+.assistantGuides button:focus-visible {
+  outline: 3px solid rgba(210, 100, 56, 0.3);
+  outline-offset: 3px;
+}
+
+.guidedAnswer {
+  display: grid;
+  gap: 0.7rem;
+  padding: 0.9rem;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.64);
+  box-shadow: inset 0 0 0 1px rgba(16, 37, 63, 0.08);
+}
+
+.answerCategory {
+  width: fit-content;
+  padding: 0.3rem 0.55rem;
+  border-radius: var(--radius-pill);
+  color: var(--color-accent-strong);
+  background: rgba(210, 100, 56, 0.12);
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.guidedAnswer h2 {
+  color: var(--color-ink-strong);
+  font-size: 1.05rem;
+  line-height: 1.25;
+}
+
+.guidedAnswer p {
+  color: var(--color-ink-soft);
+  font-size: 0.86rem;
+}
+
+.answerItems {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.answerItem {
+  display: grid;
+  gap: 0.22rem;
+  padding: 0.72rem 0.78rem;
+  border-radius: var(--radius-sm);
+  color: var(--color-ink);
+  background: rgba(255, 255, 255, 0.76);
+  box-shadow: inset 0 0 0 1px rgba(16, 37, 63, 0.08);
+}
+
+.answerItem:focus-visible {
+  outline: 3px solid rgba(210, 100, 56, 0.3);
+  outline-offset: 3px;
+}
+
+.answerItem strong {
+  color: var(--color-ink-strong);
+  font-size: 0.9rem;
+}
+
+.answerItem span,
+.answerItem em {
+  color: var(--color-ink-soft);
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
+.answerItem em {
+  color: var(--color-accent-strong);
+  font-family: var(--font-mono);
+  font-style: normal;
+}
+
+.limitNotice {
+  padding: 0.62rem 0.68rem;
+  border-radius: var(--radius-sm);
+  color: var(--color-ink-soft);
+  background: rgba(16, 37, 63, 0.05);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.limitNotice strong {
+  color: var(--color-ink);
+}
+
+.answerAction {
+  justify-self: start;
+  padding: 0.58rem 0.78rem;
+  border-radius: var(--radius-pill);
+  color: white;
+  background: var(--color-accent-strong);
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.answerAction:focus-visible {
   outline: 3px solid rgba(210, 100, 56, 0.3);
   outline-offset: 3px;
 }
@@ -203,5 +323,21 @@ section:first-of-type {
 
   .booksGrid {
     grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+}
+
+@media (max-width: 380px) {
+  .assistantGuides {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .assistantGuides button,
+  .answerItem,
+  .answerAction,
+  .quickResult,
+  .actionCard {
+    transition: none;
   }
 }

--- a/SIBiSC/src/services/guidedAssistantService.js
+++ b/SIBiSC/src/services/guidedAssistantService.js
@@ -1,0 +1,266 @@
+import { bookItems } from '../mocks/books.js';
+import { eventItems } from '../mocks/events.js';
+import { newsItems } from '../mocks/news.js';
+import { mockUser } from '../mocks/userProfile.js';
+
+export const GUIDED_ASSISTANT_LIMIT_NOTICE =
+  'Esta resposta usa dados locais do prototipo. A disponibilidade nao substitui confirmacao oficial da biblioteca e ainda nao ha reserva real nesta versao.';
+
+const catalogById = new Map(bookItems.map((book) => [book.id, book]));
+const eventById = new Map(eventItems.map((event) => [event.id, event]));
+const newsById = new Map(newsItems.map((news) => [news.id, news]));
+
+function getAvailability(book) {
+  return book.inventory.reduce(
+    (totals, item) => ({
+      availableCount: totals.availableCount + item.available,
+      totalCount: totals.totalCount + item.total,
+    }),
+    { availableCount: 0, totalCount: 0 }
+  );
+}
+
+function createBookRecommendation(bookId, reason) {
+  const book = catalogById.get(bookId);
+
+  if (!book) {
+    throw new Error(`Pergunta guiada referencia livro inexistente: ${bookId}`);
+  }
+
+  const availability = getAvailability(book);
+
+  return {
+    id: book.id,
+    bookId: book.id,
+    title: book.title,
+    author: book.author,
+    category: book.category,
+    reason,
+    availableCount: availability.availableCount,
+    totalCount: availability.totalCount,
+    source: 'catalogo-mock',
+    limit: 'Disponibilidade mockada do catalogo local; confirme com a biblioteca antes de se deslocar.',
+    nextAction: {
+      label: 'Ver detalhe no catalogo',
+      to: `/catalogo/${book.id}`,
+    },
+  };
+}
+
+function createEventReference(eventId, reason) {
+  const event = eventById.get(eventId);
+
+  if (!event) {
+    throw new Error(`Pergunta guiada referencia evento inexistente: ${eventId}`);
+  }
+
+  return {
+    id: event.id,
+    title: event.title,
+    reason,
+    source: 'agenda local mockada',
+    limit: 'Agenda de prototipo; horarios e inscricao devem ser confirmados nos canais oficiais.',
+    nextAction: {
+      label: 'Ver evento',
+      to: `/eventos/${event.id}`,
+    },
+  };
+}
+
+function createNewsReference(newsId, reason) {
+  const news = newsById.get(newsId);
+
+  if (!news) {
+    throw new Error(`Pergunta guiada referencia noticia inexistente: ${newsId}`);
+  }
+
+  return {
+    id: news.id,
+    title: news.title,
+    reason,
+    source: news.sourceLabel ?? 'noticias locais mockadas',
+    limit: 'Conteudo editorial do prototipo; consulte a fonte oficial quando precisar de confirmacao institucional.',
+    nextAction: {
+      label: 'Ler noticia',
+      to: `/noticias/${news.id}`,
+    },
+  };
+}
+
+export const guidedAssistantQuestions = [
+  {
+    id: 'literatura-brasileira',
+    label: 'Quero uma leitura de literatura brasileira',
+    shortLabel: 'Literatura brasileira',
+    category: 'Leitura',
+    answer: {
+      title: 'Sugestoes de literatura brasileira',
+      summary:
+        'Usei autores e categorias presentes nas preferencias demonstrativas do perfil para priorizar livros reais do catalogo local.',
+      recommendations: [
+        createBookRecommendation('b7', 'Autor presente nas preferencias do cadastro: Graciliano Ramos.'),
+        createBookRecommendation('b3', 'Autor presente nas preferencias do cadastro: Machado de Assis.'),
+      ],
+      source: 'catalogo-mock + preferencias demonstrativas',
+      limit: GUIDED_ASSISTANT_LIMIT_NOTICE,
+      nextAction: {
+        label: 'Explorar catalogo',
+        to: '/catalogo',
+      },
+    },
+  },
+  {
+    id: 'machado-de-assis',
+    label: 'Tenho interesse em Machado de Assis',
+    shortLabel: 'Machado de Assis',
+    category: 'Autor',
+    answer: {
+      title: 'Caminho por autor',
+      summary: 'O catalogo local possui obras de Machado de Assis com exemplares mockados disponiveis.',
+      recommendations: [
+        createBookRecommendation('b3', 'Autor corresponde diretamente ao interesse informado.'),
+        createBookRecommendation('b1', 'Autor corresponde diretamente ao interesse informado.'),
+      ],
+      source: 'catalogo-mock',
+      limit: GUIDED_ASSISTANT_LIMIT_NOTICE,
+      nextAction: {
+        label: 'Buscar Machado no catalogo',
+        to: '/catalogo',
+      },
+    },
+  },
+  {
+    id: 'cidade-sociedade',
+    label: 'Procuro temas de cidade e sociedade',
+    shortLabel: 'Cidade e sociedade',
+    category: 'Tema',
+    answer: {
+      title: 'Leituras sobre cidade, desigualdade e convivencia',
+      summary: 'Comparei o tema com resumos e categorias do catalogo local, sem consultar base oficial externa.',
+      recommendations: [
+        createBookRecommendation('b2', 'Resumo aborda desigualdade, cidade e sobrevivencia.'),
+        createBookRecommendation('b5', 'Resumo aborda cidade, habitacao coletiva e tensoes sociais.'),
+      ],
+      source: 'catalogo-mock',
+      limit: GUIDED_ASSISTANT_LIMIT_NOTICE,
+      nextAction: {
+        label: 'Ver livros do catalogo',
+        to: '/catalogo',
+      },
+    },
+  },
+  {
+    id: 'confirmar-disponibilidade',
+    label: 'Como vejo disponibilidade sem reservar?',
+    shortLabel: 'Disponibilidade',
+    category: 'Orientacao',
+    answer: {
+      title: 'Disponibilidade nesta versao',
+      summary:
+        'A disponibilidade exibida e demonstrativa e vem do inventario local do prototipo. Ela ajuda a escolher uma unidade, mas nao confirma retirada oficial.',
+      recommendations: [
+        createBookRecommendation('b7', 'Exemplo com maior contagem mockada para demonstrar a consulta por unidade.'),
+      ],
+      source: 'inventario local mockado',
+      limit: GUIDED_ASSISTANT_LIMIT_NOTICE,
+      nextAction: {
+        label: 'Abrir catalogo para conferir detalhes',
+        to: '/catalogo',
+      },
+    },
+  },
+  {
+    id: 'eventos-leitura',
+    label: 'Quais eventos combinam com leitura?',
+    shortLabel: 'Eventos de leitura',
+    category: 'Agenda',
+    answer: {
+      title: 'Eventos ligados a leitura',
+      summary: 'Selecionei eventos locais que mencionam leitura, clube do livro ou rodas culturais.',
+      references: [
+        createEventReference('e3', 'Evento conectado a Vidas Secas, livro existente no catalogo local.'),
+        createEventReference('e7', 'Roda de leitura com foco em poesia brasileira.'),
+      ],
+      source: 'agenda local mockada',
+      limit: 'Agenda do prototipo; confirme data, horario, inscricao e local nos canais oficiais antes de participar.',
+      nextAction: {
+        label: 'Ver agenda completa',
+        to: '/eventos',
+      },
+    },
+  },
+  {
+    id: 'noticias-servicos',
+    label: 'Quero entender novidades e servicos',
+    shortLabel: 'Noticias e servicos',
+    category: 'Noticias',
+    answer: {
+      title: 'Noticias para acompanhar o prototipo',
+      summary: 'Separei conteudos editoriais locais sobre servicos digitais, acervo e programacao.',
+      references: [
+        createNewsReference('n1', 'Explica a orientacao digital e reforca que a disponibilidade e mockada.'),
+        createNewsReference('n2', 'Contextualiza ampliacao de acervo e catalogacao.'),
+      ],
+      source: 'noticias locais mockadas',
+      limit: 'As noticias aparecem como conteudo de prototipo e nao substituem comunicados oficiais.',
+      nextAction: {
+        label: 'Abrir noticias',
+        to: '/noticias',
+      },
+    },
+  },
+  {
+    id: 'preferencias',
+    label: 'Minhas preferencias sao editaveis?',
+    shortLabel: 'Preferencias',
+    category: 'Perfil',
+    answer: {
+      title: 'Preferencias nesta versao',
+      summary: `As preferencias de ${mockUser.name.split(' ')[0]} sao demonstrativas: ${mockUser.readingPreferences.categories.join(', ')}. Elas ajudam a explicar recomendacoes, mas ainda nao ha edicao simples ou persistencia real nesta Sprint.`,
+      source: 'perfil mockado local',
+      limit: 'Preferencias demonstrativas; nenhuma mudanca e salva em backend real nesta versao.',
+      nextAction: {
+        label: 'Ver perfil',
+        to: '/perfil',
+      },
+    },
+  },
+  {
+    id: 'sem-reserva-real',
+    label: 'Posso reservar ou renovar pelo assistente?',
+    shortLabel: 'Reserva e renovacao',
+    category: 'Limite',
+    answer: {
+      title: 'Sem reserva real pelo assistente',
+      summary:
+        'O Feltrim Agents orienta caminhos no prototipo, mas nao executa reserva, pre-reserva, renovacao oficial ou contato com SIBI/PHL.',
+      source: 'contrato Sprint 1',
+      limit: GUIDED_ASSISTANT_LIMIT_NOTICE,
+      nextAction: {
+        label: 'Consultar detalhes no catalogo',
+        to: '/catalogo',
+      },
+    },
+  },
+  {
+    id: 'fora-do-escopo',
+    label: 'Tenho outra duvida fora desta lista',
+    shortLabel: 'Fora do escopo',
+    category: 'Fallback',
+    answer: {
+      title: 'Resposta honesta do prototipo',
+      summary:
+        'Ainda nao tenho chat aberto, IA generativa, catalogo oficial em tempo real ou integracao com atendimento. Posso orientar pelos caminhos fechados desta tela, catalogo, eventos, noticias e perfil.',
+      source: 'escopo funcional Sprint 1',
+      limit: 'Nao vou inventar disponibilidade, horario, reserva, fonte oficial ou integracao que nao existe nesta versao.',
+      nextAction: {
+        label: 'Explorar catalogo',
+        to: '/catalogo',
+      },
+    },
+  },
+];
+
+export function getGuidedAssistantQuestion(questionId) {
+  return guidedAssistantQuestions.find((question) => question.id === questionId) ?? guidedAssistantQuestions[0];
+}


### PR DESCRIPTION
## Summary
- Implementa o MVP inicial do Feltrim Agents como assistente guiado, sem chat aberto e sem prometer IA/backend real.
- Adiciona matriz de perguntas guiadas, respostas explicáveis com motivo/fonte/próxima ação e limites claros de disponibilidade mockada.
- Cria template de GitHub Issue para feedback Sofia/Claudia, evidências QA Sprint 1 e reforço do `qa-guard`.

## Issues
Closes #46
Closes #47
Closes #48
Closes #49
Closes #50
Closes #51
Closes #52
Closes #53
Closes #54

## Test plan
- `ReadLints`: sem erros
- `npm run qa:repo`
- `npm run qa:ci`
- Smoke Playwright CLI em Home/Feltrim Agents, perguntas guiadas, fallback, Catálogo/Detalhe, Perfil e `/home-mobile` em 375x812

## Notes
- Escopo mantido como assistente guiado/protótipo.
- Fora de escopo: IA generativa, backend real, integração SIBI/PHL real, reserva real e gamificação avançada.