### PR TITLE
Fix SIBiSC visual regressions

### DIFF
--- a/SIBiSC/docs/product/plano_release_final_atualizado.md
+++ b/SIBiSC/docs/product/plano_release_final_atualizado.md
@@ -1,0 +1,221 @@
+# Plano de Release Final Atualizado - SIBiSC/Feltrim Agents
+
+Data: 2026-05-19  
+Workspace: `Web_Mobile`  
+App: `SIBiSC`  
+Branch local no momento da leitura: `fix/sibisc-visual-regressions`  
+Status local inicial: branch alinhada com `origin/fix/sibisc-visual-regressions`, sem alteracoes locais antes da criacao deste documento.
+
+## 1. Resumo executivo
+
+A recomendacao atual e **revisar e mergear o PR #61 antes do PR #59**.
+
+Motivo: o PR #61 corrige regressoes visuais percebidas depois do hardening, esta `MERGEABLE`, com `mergeStateStatus: CLEAN`, QA Gate verde, Vercel verde e Netlify preview verde. O PR #59 continua tecnicamente mergeable, mas esta `UNSTABLE` por checks Netlify externos falhando e toca alguns dos mesmos arquivos de Home/estilos. Mergear #61 primeiro estabiliza a experiencia visual em `main`; em seguida, o PR #59 deve ser atualizado contra `main` para preservar as correcoes visuais junto com as melhorias de acessibilidade, evidencias e hardening.
+
+O release final ainda nao deve ser considerado GO irrestrito ate que:
+
+- o dominio publico Vercel seja validado no dashboard e em producao;
+- o roteiro com leitor de tela real seja executado e registrado;
+- o PR #59 seja revalidado depois da entrada do PR #61;
+- a decisao sobre Netlify seja explicitada como nao bloqueante ou resolvida como check obrigatorio.
+
+## 2. Estado atual dos PRs
+
+### PRs abertos
+
+| PR | Branch | Estado | Mergeability | Checks principais | Leitura |
+| --- | --- | --- | --- | --- | --- |
+| #61 - `Fix SIBiSC visual regressions` | `fix/sibisc-visual-regressions` -> `main` | `OPEN` | `MERGEABLE`, `CLEAN` | QA Gate P0/P1 verde, Vercel verde, Netlify preview verde | Pronto para review prioritario. |
+| #59 - `Finalize SIBiSC Sprint 3 hardening release` | `release/sibisc-hardening-sprint3` -> `main` | `OPEN` | `MERGEABLE`, `UNSTABLE` | QA Gate P0/P1 verde, Vercel verde, Netlify failure | Bom candidato de release, mas precisa ser atualizado/revalidado apos #61. |
+
+### PR ja resolvido
+
+| PR | Branch | Estado | Impacto |
+| --- | --- | --- | --- |
+| #60 - `fix(sibisc): consolidate deploy 404 configuration` | `fix/sibisc-deploy-404` -> `main` | `MERGED` em 2026-05-19 15:05 UTC | Consolida configuracao raiz de deploy para Vercel/Netlify e reduz risco de 404 por root/output incorreto. |
+
+### Issues abertas relacionadas
+
+Ainda existem issues R1/R1.1 abertas de QA, docs, dados e operacao minima, incluindo `US-MVP-QA-001`, `T-QA-001` a `T-QA-004`, `T-BASE-001/002/004`, `T-OPS-001/003` e `T-ACV-003`. Para este release, elas devem ser tratadas como backlog ou criterios de aceite apenas se o escopo da entrega final exigir fechamento formal dessas issues.
+
+## 3. Ordem recomendada de merge
+
+### Ordem recomendada
+
+1. Review humano do PR #61.
+2. Merge do PR #61 em `main`, se o review confirmar que a correcao visual esta adequada.
+3. Atualizar o PR #59 contra o novo `main` (`rebase` ou merge de `main` na branch, conforme preferencia operacional).
+4. Resolver eventuais conflitos em `HomePage.jsx`, `HomePageMobile.jsx` e `globals.css`.
+5. Reexecutar validacoes do PR #59 depois da atualizacao.
+6. Review humano do PR #59 com foco em acessibilidade, evidencias e release notes.
+7. Executar e registrar leitor de tela real.
+8. Merge final do PR #59.
+9. Validar producao no dominio publico Vercel.
+
+### Justificativa
+
+O PR #61 e menor, mais recente e corrige diretamente a percepcao visual da entrega. Ele tambem esta limpo para merge e com os checks relevantes verdes. O PR #59 e maior e contem evidencias de release, Lighthouse, screenshots e hardening. Como #59 e #61 alteram arquivos comuns, principalmente Home e estilos globais, a sequencia #61 -> atualizar #59 reduz a chance de publicar uma release tecnicamente correta mas visualmente regressiva.
+
+Mergear #59 antes de #61 tambem e possivel do ponto de vista Git, mas aumenta o risco de o PR visual precisar ser reinterpretado sobre uma base com hardening, alem de deixar `main` temporariamente com uma experiencia visual que ja foi identificada como regressiva.
+
+## 4. Riscos de conflito
+
+### Risco alto/moderado
+
+Arquivos tocados por #59 e #61:
+
+- `SIBiSC/src/pages/HomePage.jsx`
+- `SIBiSC/src/pages/HomePageMobile.jsx`
+- `SIBiSC/src/styles/globals.css`
+
+Risco: conflitos ou regressao sem conflito textual. O caso mais provavel nao e apenas conflito Git; e uma combinacao onde uma mudanca de acessibilidade/hardening do #59 e uma mudanca visual do #61 coexistem, mas precisam de nova validacao manual.
+
+### Risco baixo
+
+Arquivos exclusivos do #61:
+
+- `SIBiSC/src/components/layout/AppLayout.jsx`
+- `SIBiSC/src/components/layout/AppLayout.module.css`
+- `SIBiSC/src/components/layout/BottomNav.module.css`
+- `SIBiSC/src/pages/HomePage.module.css`
+- `SIBiSC/src/pages/HomePageMobile.module.css`
+- `SIBiSC/docs/qa/visual_regressions_fix.md`
+
+Arquivos exclusivos do #59:
+
+- `SIBiSC/docs/product/release_go_no_go_sprint3.md`
+- `SIBiSC/docs/qa/sprint3_hardening_release.md`
+- evidencias Lighthouse e screenshots em `SIBiSC/docs/qa/`
+
+Risco: baixo para conflito textual, mas alto volume documental em #59 exige review cuidadoso para evitar ruido na release.
+
+## 5. Relacao entre visual fix, hardening e deploy 404
+
+### Correcao visual (#61)
+
+O PR #61 estabiliza a composicao da Home, Home mobile, header, bottom nav e rodape de bibliotecas. Ele responde a regressoes visuais percebidas pelo usuario e deve ser considerado prerequisito de qualidade visual antes do release final.
+
+### Hardening/release (#59)
+
+O PR #59 documenta e aplica hardening de acessibilidade, `prefers-reduced-motion`, evidencias Lighthouse, smokes Edge e criterios Go/No-Go. Ele e a camada de release final, mas deve ser recalibrado depois que a base visual correta entrar em `main`.
+
+### Deploy 404 (#60)
+
+O PR #60 ja entrou em `main` e reduziu o risco de deploy incorreto em monorepo ao consolidar configuracoes raiz. Ele nao substitui a acao no dashboard Vercel: o diagnostico ainda aponta para alias/dominio/protecao de deployment como fonte provavel do 404 publico.
+
+Leitura combinada: #60 corrige a infraestrutura versionada, #61 corrige a experiencia visual, #59 fecha a release com evidencias e criterios de aceite.
+
+## 6. Checklist Vercel dashboard
+
+Objetivo: resolver e confirmar o dominio publico `https://sibisc-hub-cultural.vercel.app`.
+
+- Abrir `https://vercel.com/rafeltrims-projects/sibisc-hub-cultural`.
+- Em `Settings > Git`, confirmar:
+  - repository: `RaFeltrim/sibisc-hub-cultural`;
+  - production branch: `main`;
+  - root directory: preferencialmente `SIBiSC`, ou raiz do repo usando o `vercel.json` raiz do PR #60;
+  - build command coerente com o root escolhido;
+  - output directory coerente com o root escolhido.
+- Em `Settings > Domains`, confirmar:
+  - `sibisc-hub-cultural.vercel.app` esta associado ao projeto correto;
+  - nenhum alias antigo aponta para deployment inexistente;
+  - o dominio esperado aparece como dominio de producao.
+- Em `Deployments`, abrir o ultimo deployment de `main` depois do merge final:
+  - confirmar commit/branch;
+  - confirmar status `Ready` ou equivalente;
+  - se necessario, usar `Promote to Production` ou `Redeploy`.
+- Em `Deployment Protection`, decidir:
+  - para apresentacao publica, producao deve estar publica;
+  - se a protecao for mantida, documentar forma de acesso sem commitar bypass token.
+- Validar manualmente:
+  - `https://sibisc-hub-cultural.vercel.app`;
+  - `https://sibisc-hub-cultural.vercel.app/home-mobile`;
+  - `https://sibisc-hub-cultural.vercel.app/catalogo`;
+  - `https://sibisc-hub-cultural.vercel.app/catalogo/b1`;
+  - `https://sibisc-hub-cultural.vercel.app/perfil`;
+  - `https://sibisc-hub-cultural.vercel.app/eventos`.
+
+## 7. Checklist leitor de tela real
+
+Status atual: pendente operacional. Continua bloqueante para GO final irrestrito.
+
+Ambiente recomendado:
+
+- Windows + NVDA + Edge, ou macOS + VoiceOver + Safari/Chrome.
+- Preview do PR #59 atualizado apos merge do #61, ou producao final se o teste for feito apos merge.
+
+Roteiro minimo:
+
+- Navegar por teclado em `/`, `/home-mobile`, `/catalogo`, `/catalogo/b1`, `/perfil` e `/eventos`.
+- Confirmar titulo/landmarks principais e ausencia de armadilha de foco.
+- Na Home, alternar perguntas guiadas e confirmar anuncio da resposta em regiao viva.
+- Na Home mobile, confirmar que header e bottom nav nao escondem controles e que o foco segue ordem logica.
+- No Catalogo, buscar por `vidas` e confirmar anuncio do status da busca.
+- No Detalhe, navegar pelas unidades e confirmar que disponibilidade/estado sao compreensiveis.
+- No Perfil, alternar abas Emprestimos/Historico/Favoritos e confirmar relacao tab/painel.
+- No Perfil, acionar Renovar e Remover favorito e confirmar mensagem de status.
+- Em Eventos, abrir detalhe e acionar Google Calendar, confirmando aviso de nova aba.
+- Registrar data, navegador, leitor, pessoa validadora, rotas testadas e achados.
+
+Criterio de aceite: nenhum controle sem nome acessivel, nenhum fluxo principal impossivel sem mouse, estados selecionados compreensiveis e mensagens dinamicas anunciadas.
+
+## 8. Decisao Netlify
+
+Recomendacao: **Netlify nao deve bloquear o release de produto se Vercel for o canal oficial de entrega**.
+
+Justificativa:
+
+- O PR #59 esta `UNSTABLE` por failures do Netlify, mas QA Gate e Vercel passaram.
+- O diagnostico do deploy 404 ja indicava que Netlify possui risco de configuracao externa de base/publish.
+- O PR #61 mostra Netlify preview verde, sugerindo que a falha do #59 pode ser externa, transient ou ligada a estado/configuracao especifica do preview.
+
+Excecao: se Netlify estiver marcado como required check no GitHub ou se for exigido pela disciplina como ambiente de entrega, entao ele vira bloqueador processual ate ser corrigido ou formalmente removido/dispensado como required check.
+
+## 9. Sequencia final ate release
+
+- Revisar PR #61, incluindo comparacao visual nas rotas `/` e `/home-mobile`.
+- Mergear PR #61 em `main` se aprovado.
+- Atualizar PR #59 contra `main`.
+- Conferir conflito e regressao nos arquivos compartilhados: `HomePage.jsx`, `HomePageMobile.jsx`, `globals.css`.
+- Reexecutar validacoes locais do #59 atualizado:
+  - `npm run qa:repo`;
+  - `npm run qa:ci`;
+  - smoke visual nas rotas principais;
+  - lints/diagnosticos dos arquivos tocados.
+- Aguardar checks remotos do #59 atualizado.
+- Reavaliar Netlify: nao bloqueante se Vercel for oficial; bloqueante se required check.
+- Executar leitor de tela real e registrar evidencia.
+- Review humano final do #59.
+- Mergear #59.
+- Validar producao Vercel e dominio publico.
+- Registrar status final e qualquer pendencia pos-release.
+
+## 10. Matriz Go/No-Go
+
+| Criterio | Status atual | Decisao |
+| --- | --- | --- |
+| PR #61 visual | QA Gate, Vercel e Netlify verdes; mergeability limpa | GO para review/merge prioritario. |
+| PR #59 hardening | QA Gate e Vercel verdes; Netlify falhando; mergeable mas unstable | GO condicional para manter em review; NO-GO para merge antes de atualizar apos #61. |
+| Conflitos entre #61 e #59 | Risco em Home/Home mobile/globals | NO-GO para merge final do #59 sem revalidacao apos #61. |
+| Deploy 404 publico | PR #60 mergeado, mas dashboard Vercel ainda precisa confirmacao | NO-GO para release publica se dominio continuar 404/401/protegido. |
+| Leitor de tela real | Pendente | NO-GO para GO final irrestrito. |
+| Netlify | Falha em #59, sucesso em #61 | Nao bloqueante para produto se Vercel for oficial; bloqueante se required check. |
+| QA Gate GitHub | P0/P1 verdes em #59 e #61 | GO tecnico para continuidade. |
+| Review humano | Pendente nos PRs abertos | NO-GO para merge automatico. |
+
+## 11. Comentarios nos PRs
+
+Nao foi feito comentario automatico em PR.
+
+Recomendacao:
+
+- Comentar no PR #61 apenas se o documento de planejamento for mantido em branch/documentacao compartilhada, avisando que ele deve entrar antes do #59.
+- Comentar no PR #59 depois do merge do #61, informando que a branch precisa ser atualizada contra `main` e revalidada por causa dos arquivos compartilhados.
+
+## 12. Decisoes pendentes do usuario
+
+- Confirmar se #61 pode ser priorizado para merge antes de #59.
+- Confirmar se Netlify e required check/processo obrigatorio ou apenas preview secundario.
+- Executar ou delegar a validacao com leitor de tela real.
+- Resolver no dashboard Vercel a exposicao publica do dominio.
+- Decidir se este documento deve ser commitado em branch propria/documental ou anexado a algum PR existente. A recomendacao e nao misturar este plano ao PR #61 sem decisao explicita.

--- a/SIBiSC/docs/qa/visual_regressions_fix.md
+++ b/SIBiSC/docs/qa/visual_regressions_fix.md
@@ -1,0 +1,26 @@
+# Correção de Regressões Visuais
+
+## Problemas corrigidos
+
+- O bloco global de bibliotecas deixou de competir com a Home como uma segunda seção hero. O texto foi reescrito e o rodapé passou a ser um bloco compacto de unidades, horários e contatos.
+- O espaçamento excessivo antes e depois do rodapé foi reduzido, mantendo folga suficiente para a navegação inferior fixa em mobile.
+- Os cards de bibliotecas passaram a usar grid responsivo com largura mínima, evitando colunas espremidas em desktop/tablet.
+- O cabeçalho mobile foi compactado: a faixa superior é ocultada em telas pequenas, o badge diminuiu e a ribbon de fatos não empurra mais o conteúdo no mobile.
+- A Home mobile passou a escopar os estilos de seções em classes locais, evitando vazamento de CSS para outros `section`.
+- O bottom nav mobile ficou mais leve e baixo, com menor largura, sombra e altura.
+- O hero desktop da Home foi compactado: tipografia menor, console menos alto e painel guiado com rolagem interna controlada em desktop.
+
+## Validação
+
+- Edge/Playwright CLI em `1366x900` na rota `/`: hero desktop medido em aproximadamente `944px`, cards do rodapé com largura estável de `283px`.
+- Edge/Playwright CLI em `820x1180` na rota `/`: header com `105px`, bottom nav visível e cards do rodapé em uma coluna larga sem compressão.
+- Edge/Playwright CLI em `390x844` na rota `/home-mobile`: header com `53px`, primeira seção iniciando em `64px`, perguntas guiadas abaixo da introdução e bottom nav com `54px`.
+- Edge/Playwright CLI em `390x844` no fim da rota `/home-mobile`: rodapé termina acima do bottom nav, com cerca de `77px` de respiro documental abaixo do conteúdo.
+- `ReadLints` não encontrou erros nos arquivos editados.
+- `npm run qa:repo` passou.
+- `npm run qa:ci` passou, incluindo `vite build`.
+
+## Riscos residuais
+
+- A rota `/` continua sendo uma Home rica em conteúdo também em viewport mobile; a rota `/home-mobile` permanece como experiência mobile dedicada.
+- O painel guiado da Home desktop usa rolagem interna a partir de desktop largo para manter a composição do hero sob controle sem remover conteúdo de Feltrim Agents.

--- a/SIBiSC/src/components/layout/AppLayout.jsx
+++ b/SIBiSC/src/components/layout/AppLayout.jsx
@@ -79,8 +79,8 @@ function AppLayout() {
 
       <footer className={styles.footer}>
         <div className={styles.footerIntro}>
-          <span className={styles.footerEyebrow}>Rede ativa</span>
-          <h2>As bibliotecas do SIBiSC continuam proximas da rotina da cidade.</h2>
+          <span className={styles.footerEyebrow}>Bibliotecas da rede</span>
+          <h2>Unidades, horários e contatos em um bloco compacto.</h2>
           <p>
             Consulte horários, descubra eventos por bairro e encontre o melhor ponto de retirada
             para cada livro.

--- a/SIBiSC/src/components/layout/AppLayout.module.css
+++ b/SIBiSC/src/components/layout/AppLayout.module.css
@@ -51,7 +51,7 @@
   grid-template-columns: auto 1fr auto;
   gap: var(--space-md);
   align-items: center;
-  padding: 1rem 0;
+  padding: 0.85rem 0;
 }
 
 .brandWrap {
@@ -174,7 +174,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.65rem;
-  padding: 1rem 0 0;
+  padding: 0.8rem 0 0;
 }
 
 .ribbonInner span {
@@ -198,14 +198,14 @@
 
 .footer {
   width: min(100%, var(--content-width));
-  margin: var(--space-3xl) auto calc(6rem + var(--space-xl));
+  margin: var(--space-2xl) auto calc(5rem + env(safe-area-inset-bottom));
   padding: 0 var(--space-md);
 }
 
 .footerIntro {
   display: grid;
-  gap: var(--space-sm);
-  max-width: 42rem;
+  gap: var(--space-xs);
+  max-width: 44rem;
 }
 
 .footerEyebrow {
@@ -222,21 +222,24 @@
 }
 
 .footerIntro h2 {
-  font-size: clamp(1.9rem, 4vw, 3rem);
+  max-width: 22ch;
+  font-size: clamp(1.35rem, 2.6vw, 2rem);
+  line-height: 1.08;
 }
 
 .footerGrid {
-  margin-top: var(--space-xl);
+  margin-top: var(--space-lg);
   display: grid;
-  gap: var(--space-md);
+  gap: var(--space-sm);
 }
 
 .footerCard {
   display: grid;
-  gap: 0.75rem;
-  padding: 1.2rem;
+  gap: 0.55rem;
+  min-width: 0;
+  padding: 0.95rem;
   border: 1px solid rgba(18, 38, 63, 0.08);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.62);
   box-shadow: var(--shadow-soft);
 }
@@ -250,14 +253,15 @@
 }
 
 .footerCard strong {
-  font-size: 1.05rem;
+  font-size: 0.98rem;
+  line-height: 1.25;
 }
 
 .footerMeta {
   display: grid;
-  gap: 0.35rem;
+  gap: 0.25rem;
   color: var(--color-ink-soft);
-  font-size: 0.92rem;
+  font-size: 0.84rem;
 }
 
 @media (max-width: 719px) {
@@ -277,18 +281,25 @@
   }
 
   .footerGrid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   }
 }
 
 @media (max-width: 899px) {
+  .topline {
+    padding: 0.42rem 0;
+    font-size: 0.76rem;
+  }
+
   .headerInner {
     grid-template-columns: 1fr;
     justify-items: start;
+    padding: 0.65rem 0;
   }
 
   .footer {
-    margin-bottom: calc(7rem + var(--space-xl));
+    margin-top: var(--space-xl);
+    margin-bottom: calc(4.8rem + env(safe-area-inset-bottom));
   }
 }
 
@@ -297,13 +308,40 @@
     padding-inline: var(--space-sm);
   }
 
+  .topline {
+    display: none;
+  }
+
+  .headerInner {
+    padding: 0.5rem 0;
+  }
+
+  .brandLink {
+    gap: 0.7rem;
+  }
+
+  .brandCopy span {
+    display: none;
+  }
+
   .ribbon,
   .footer {
     padding-inline: var(--space-sm);
   }
 
+  .ribbon {
+    display: none;
+  }
+
   .brandBadge {
-    width: 2.8rem;
-    height: 2.8rem;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 0.75rem;
+    font-size: 0.82rem;
+  }
+
+  .footerGrid {
+    gap: var(--space-xs);
+    margin-top: var(--space-md);
   }
 }

--- a/SIBiSC/src/components/layout/BottomNav.module.css
+++ b/SIBiSC/src/components/layout/BottomNav.module.css
@@ -1,19 +1,19 @@
 .nav {
   position: fixed;
   left: 50%;
-  bottom: max(0.85rem, env(safe-area-inset-bottom));
+  bottom: max(0.55rem, env(safe-area-inset-bottom));
   transform: translateX(-50%);
   z-index: 15;
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 0.28rem;
-  width: min(92vw, 520px);
-  padding: 0.42rem;
+  gap: 0.18rem;
+  width: min(90vw, 500px);
+  padding: 0.34rem;
   border: 1px solid rgba(255, 255, 255, 0.24);
   border-radius: calc(var(--radius-pill) + 8px);
-  background: rgba(18, 38, 63, 0.82);
-  box-shadow: 0 20px 54px rgba(18, 38, 63, 0.26);
-  backdrop-filter: blur(20px);
+  background: rgba(18, 38, 63, 0.76);
+  box-shadow: 0 14px 38px rgba(18, 38, 63, 0.22);
+  backdrop-filter: blur(18px);
   animation: nav-in 420ms ease both;
 }
 
@@ -22,7 +22,7 @@
   display: grid;
   justify-items: center;
   gap: 0.16rem;
-  padding: 0.58rem 0.28rem;
+  padding: 0.46rem 0.22rem;
   border-radius: var(--radius-pill);
   text-align: center;
   color: rgba(255, 255, 255, 0.72);
@@ -60,8 +60,8 @@
 .icon {
   display: grid;
   place-items: center;
-  width: 2rem;
-  height: 2rem;
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.08);
   transition:
@@ -92,23 +92,23 @@
 
 @media (max-width: 560px) {
   .nav {
-    bottom: max(0.5rem, env(safe-area-inset-bottom));
+    bottom: max(0.35rem, env(safe-area-inset-bottom));
     gap: 0.12rem;
-    width: min(calc(100vw - 2rem), 460px);
-    padding: 0.25rem;
+    width: min(calc(100vw - 1.4rem), 440px);
+    padding: 0.22rem;
     border-radius: 1.65rem;
   }
 
   .link {
     gap: 0.12rem;
-    min-height: 3rem;
-    padding: 0.34rem 0.12rem;
-    font-size: 0.63rem;
+    min-height: 2.65rem;
+    padding: 0.28rem 0.1rem;
+    font-size: 0.61rem;
   }
 
   .icon {
-    width: 1.45rem;
-    height: 1.45rem;
+    width: 1.3rem;
+    height: 1.3rem;
   }
 
   .icon svg {

--- a/SIBiSC/src/pages/HomePage.jsx
+++ b/SIBiSC/src/pages/HomePage.jsx
@@ -332,15 +332,12 @@ function HomePage() {
                 </p>
                 <p className={styles.limitNotice}>{GUIDED_ASSISTANT_LIMIT_NOTICE}</p>
                 <div className={styles.recommendationList}>
-                  {assistantRecommendations.map((book) => (
+                  {assistantRecommendations.slice(0, 1).map((book) => (
                     <Link key={book.id} className={styles.recommendationItem} to={`/catalogo/${book.bookId}`}>
                       <strong>{book.title}</strong>
                       <span>Motivo: {book.reason}</span>
-                      <span>
-                        Fonte/limite: {book.source}; disponibilidade mockada do catálogo local, sem reserva real.
-                      </span>
                       <em>
-                        Próxima ação: abrir detalhe. {book.availableCount} exemplares disponíveis no catálogo local.
+                        Abrir detalhe. {book.availableCount} exemplares disponíveis no catálogo local.
                       </em>
                     </Link>
                   ))}

--- a/SIBiSC/src/pages/HomePage.module.css
+++ b/SIBiSC/src/pages/HomePage.module.css
@@ -3,11 +3,11 @@
   isolation: isolate;
   overflow: hidden;
   display: grid;
-  gap: var(--space-xl);
+  gap: var(--space-lg);
   align-items: center;
-  min-height: min(760px, calc(100svh - 10rem));
+  min-height: min(680px, calc(100svh - 8rem));
   padding: clamp(1.4rem, 4vw, 4rem);
-  margin-top: var(--space-lg);
+  margin-top: var(--space-md);
   border: 1px solid rgba(16, 37, 63, 0.1);
   border-radius: calc(var(--radius-lg) + 4px);
   background:
@@ -59,9 +59,9 @@
 }
 
 .hero h1 {
-  max-width: 10ch;
-  font-size: clamp(3rem, 8vw, 6.9rem);
-  line-height: 0.86;
+  max-width: 14ch;
+  font-size: clamp(2.6rem, 5.4vw, 4.35rem);
+  line-height: 0.95;
 }
 
 .description {
@@ -421,7 +421,7 @@
 
 .heroPanel {
   display: grid;
-  gap: var(--space-md);
+  gap: var(--space-sm);
   padding: clamp(1rem, 3vw, var(--space-lg));
   border-radius: var(--radius-md);
   background: rgba(255, 252, 247, 0.84);
@@ -649,7 +649,7 @@
   overflow: hidden;
   display: grid;
   gap: 0.2rem;
-  padding: 0.9rem 1rem;
+  padding: 0.82rem 0.9rem;
   border-radius: var(--radius-sm);
   background: rgba(18, 38, 63, 0.06);
 }
@@ -704,14 +704,14 @@
 
 .recommendationList {
   display: grid;
-  gap: 0.6rem;
-  margin-top: 0.5rem;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
 }
 
 .recommendationItem {
   display: grid;
   gap: 0.18rem;
-  padding: 0.8rem 0.9rem;
+  padding: 0.68rem 0.75rem;
   border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.68);
   box-shadow: inset 0 0 0 1px rgba(18, 38, 63, 0.08);
@@ -855,10 +855,6 @@
 }
 
 @media (min-width: 900px) {
-  .hero {
-    grid-template-columns: minmax(0, 0.95fr) minmax(420px, 0.82fr);
-  }
-
   .commandLinks {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
@@ -873,6 +869,40 @@
 
   .feedbackAction {
     grid-column: 1 / -1;
+  }
+}
+
+@media (min-width: 1040px) {
+  .hero {
+    grid-template-columns: minmax(0, 1.12fr) minmax(430px, 0.88fr);
+  }
+
+  .heroPanel {
+    max-height: min(440px, calc(100svh - 12rem));
+    overflow: auto;
+    scrollbar-gutter: stable;
+  }
+
+  .console {
+    gap: var(--space-sm);
+    padding: 1rem;
+  }
+
+  .consoleHeader strong {
+    font-size: clamp(1.25rem, 2vw, 1.75rem);
+  }
+
+  .pipelineItem {
+    padding: 0.68rem 0.75rem;
+  }
+
+  .pipelineItem p,
+  .pipelineItem em {
+    display: none;
+  }
+
+  .consoleMetrics span {
+    padding: 0.58rem 0.65rem;
   }
 }
 
@@ -897,6 +927,7 @@
 @media (max-width: 560px) {
   .hero {
     padding: var(--space-md);
+    margin-top: var(--space-sm);
     border-radius: var(--radius-lg);
   }
 

--- a/SIBiSC/src/pages/HomePageMobile.jsx
+++ b/SIBiSC/src/pages/HomePageMobile.jsx
@@ -281,7 +281,7 @@ function HomePageMobile() {
 
       {/* News Section */}
       {news.length > 0 && (
-        <section>
+        <section className={styles.contentSection}>
           <SectionHeader
             eyebrow="Novidades"
             title="Últimas notícias"
@@ -298,7 +298,7 @@ function HomePageMobile() {
 
       {/* Events Section */}
       {events.length > 0 && (
-        <section>
+        <section className={styles.contentSection}>
           <SectionHeader
             eyebrow="Agenda"
             title="Próximos encontros"
@@ -315,7 +315,7 @@ function HomePageMobile() {
 
       {/* Featured Books Section */}
       {books.length > 0 && (
-        <section>
+        <section className={styles.contentSection}>
           <SectionHeader
             eyebrow="Destaques"
             title="Livros em destaque"

--- a/SIBiSC/src/pages/HomePageMobile.module.css
+++ b/SIBiSC/src/pages/HomePageMobile.module.css
@@ -1,16 +1,16 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: var(--space-lg);
-  padding-bottom: var(--space-lg);
+  gap: var(--space-md);
+  padding-bottom: var(--space-md);
 }
 
 /* Mobile Hero Section */
 .mobileHero {
   display: grid;
-  gap: var(--space-md);
-  padding: var(--space-md);
-  margin-top: var(--space-sm);
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  margin-top: var(--space-xs);
   background: linear-gradient(135deg, rgba(197, 95, 52, 0.12), rgba(16, 37, 63, 0.08));
   border-radius: var(--radius-lg);
 }
@@ -21,7 +21,7 @@
 }
 
 .heroTitle {
-  font-size: clamp(1.5rem, 4vw, 2rem);
+  font-size: clamp(1.45rem, 7vw, 2rem);
   line-height: 1.2;
   color: var(--color-ink-strong);
 }
@@ -54,14 +54,14 @@
 .assistantGuides {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.45rem;
+  gap: 0.38rem;
 }
 
 .assistantGuides button {
   display: grid;
   gap: 0.16rem;
-  min-height: 2.2rem;
-  padding: 0.55rem 0.75rem;
+  min-height: 2rem;
+  padding: 0.48rem 0.65rem;
   border: 0;
   border-radius: var(--radius-pill);
   color: var(--color-accent-strong);
@@ -97,8 +97,8 @@
 
 .guidedAnswer {
   display: grid;
-  gap: 0.7rem;
-  padding: 0.9rem;
+  gap: 0.6rem;
+  padding: 0.78rem;
   border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.64);
   box-shadow: inset 0 0 0 1px rgba(16, 37, 63, 0.08);
@@ -329,13 +329,8 @@
   color: var(--color-ink-strong);
 }
 
-/* Sections */
-section {
+.contentSection {
   padding: 0 var(--space-md);
-}
-
-section:first-of-type {
-  padding-top: var(--space-md);
 }
 
 /* Stack Layout */
@@ -347,14 +342,14 @@ section:first-of-type {
 /* Books Grid */
 .booksGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: var(--space-md);
+  grid-template-columns: 1fr;
+  gap: var(--space-sm);
 }
 
 /* Responsive */
 @media (min-width: 640px) {
   .container {
-    gap: var(--space-xl);
+    gap: var(--space-lg);
   }
 
   .mobileHero {
@@ -370,7 +365,7 @@ section:first-of-type {
     margin: 0 var(--space-lg);
   }
 
-  section {
+  .contentSection {
     padding: 0 var(--space-lg);
   }
 
@@ -379,7 +374,13 @@ section:first-of-type {
   }
 
   .booksGrid {
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 860px) {
+  .booksGrid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }
 

--- a/SIBiSC/src/styles/globals.css
+++ b/SIBiSC/src/styles/globals.css
@@ -69,7 +69,7 @@ input:focus-visible {
 main {
   width: min(100%, var(--content-width));
   margin: 0 auto;
-  padding: 0 var(--space-md) calc(6rem + var(--space-xl));
+  padding: 0 var(--space-md) var(--space-2xl);
 }
 
 h1,


### PR DESCRIPTION
## Summary
- Compact the global library footer so it no longer reads like a duplicate hero section.
- Reduce mobile header/ribbon footprint, lighten the bottom nav, and preserve bottom clearance.
- Tighten Home/Home mobile grids, spacing, and guided assistant composition without removing Sprint 1/2 features.

## Test plan
- ReadLints on edited source/CSS files.
- Edge/Playwright CLI visual checks at 1366x900, 820x1180, and 390x844 for `/` and `/home-mobile`.
- `npm run qa:repo`
- `npm run qa:ci`

## Notes
- Based on `origin/main` instead of PR #59 because PR #59 is Sprint 3 hardening documentation, while this changes app UI and should minimize conflicts.
- Added `SIBiSC/docs/qa/visual_regressions_fix.md` with validation details and residual risks.