### PR TITLE
fix(sibisc): close final sprint gaps

### DIFF
--- a/SIBiSC/docs/product/go_no_go_final_pos_fechamento.md
+++ b/SIBiSC/docs/product/go_no_go_final_pos_fechamento.md
@@ -1,0 +1,52 @@
+# Go/No-Go final pos-fechamento - SIBiSC/Feltrim Agents
+
+Data: 2026-05-19  
+Branch: `fix/sibisc-final-closure`  
+Documento de evidencias: `SIBiSC/docs/qa/sprint_final_fechamento_evidencias.md`
+
+## Decisao executiva
+
+**GO para apresentacao publica controlada como prototipo academico demonstrativo.**
+
+A sprint final reduziu os principais riscos de promessa operacional: disponibilidade, perfil, renovacao, favoritos e progresso pessoal agora comunicam com mais clareza que usam dados locais/mockados. O bug mobile do botao `Buscar` foi validado em Edge/Playwright no viewport `390x844`, e os gates locais passaram.
+
+**NO-GO para produto operacional ou release sem ressalvas.**
+
+O projeto continua sem backend real, reserva real, renovacao oficial, integracao com SIBI/PHL, persistencia de dados pessoais e governanca operacional.
+
+**NO-GO para declarar acessibilidade final ou conformidade completa.**
+
+Foram corrigidos `h1`, descoberta do Perfil e `aria-controls` das abas, mas nao houve validacao humana real com leitor de tela nem medicao formal de contraste.
+
+## Status por frente
+
+| Frente | Status | Observacao |
+| --- | --- | --- |
+| SF-01 disponibilidade mockada | Corrigido | Avisos em catalogo, cards, detalhe e unidades. |
+| SF-07 renovacao/perfil demonstrativo | Corrigido | Perfil marcado no topo e renovacao renomeada para simulacao. |
+| SF-02 bottom nav mobile | Corrigido | Smoke confirmou clique no `Buscar` em `/home-mobile`. |
+| SF-04 acessibilidade estrutural | Corrigido | `h1`, Perfil desktop e paineis de tabs ajustados. |
+| SF-03 leitor de tela | Pendente documentado | Narrator existe, NVDA nao encontrado; sem validacao auditiva humana. |
+| SF-05 headers/404 | Parcial corrigido | Headers e rewrites Vercel implementados; confirmar em preview Vercel. |
+| SF-08 Jornada do leitor | Corrigido | Progresso acima da meta aparece como meta concluida. |
+| SF-06 feedback alternativo | Corrigido | Roteiro local copiavel sem GitHub login. |
+| SF-09 acabamentos P3 | Parcial corrigido | `noopener noreferrer` e microcopy; contraste formal pendente. |
+
+## Validacoes finais locais
+
+- `ReadLints`: sem erros nos arquivos editados.
+- `npm run qa:repo`: passou.
+- `npm run qa:ci`: passou com build Vite.
+- Smoke Playwright/Edge: passou nas rotas `/`, `/home-mobile`, `/catalogo`, `/catalogo/b1`, `/perfil` e UI 404 de rota inexistente.
+- Caso mobile critico: `Eventos de leitura` + `Sapiens` + clique em `Buscar` passou.
+
+## Ressalvas para apresentacao
+
+O roteiro publico deve repetir que o SIBiSC/Feltrim Agents e um prototipo academico: dados locais/mockados, sem reserva real, sem renovacao oficial, sem backend de IA generativa e sem integracao operacional. O feedback sem GitHub existe como roteiro local copiavel, nao como canal institucional definitivo.
+
+## Pendencias antes de comunicar maturidade maior
+
+1. Validar o PR/deploy preview Vercel para confirmar headers e semantica HTTP 404 fora do `vite preview`.
+2. Executar roteiro humano com Narrator/NVDA e registrar resultado auditivo real.
+3. Medir contraste formal em pontos criticos antes de declarar WCAG AA.
+4. Rafael escolher canal definitivo de feedback sem GitHub se o projeto for apresentado a publico nao tecnico amplo.

--- a/SIBiSC/docs/qa/review_pr62_final_closure.md
+++ b/SIBiSC/docs/qa/review_pr62_final_closure.md
@@ -1,0 +1,112 @@
+# Review final QA/TL/SE - PR #62
+
+Data: 2026-05-19  
+PR: [#62](https://github.com/RaFeltrim/sibisc-hub-cultural/pull/62)  
+Branch: `fix/sibisc-final-closure`  
+Base revisada: `origin/main...HEAD`  
+Commit revisado: `0e4e04f60e28e1d81049b2b0a54e73682838b08b`
+
+## Veredito
+
+**GO para merge do PR #62 como fechamento final do prototipo academico demonstrativo.**
+
+Nao encontrei achados bloqueantes no diff contra `main`. Os itens que motivaram o PR foram tratados de forma coerente com o escopo: a interface evita prometer operacao real, os dados mockados estao sinalizados, o bug mobile do botao `Buscar` foi validado em Edge, e os documentos Go/No-Go preservam pendencias reais sem declarar maturidade indevida.
+
+**Ressalva de release:** o preview Vercel do PR respondeu `401`, portanto a validacao externa de headers e HTTP 404 real nao foi conclusiva. Isso nao contradiz os documentos do PR, que ja tratam essa frente como pendencia/parcial, mas deve permanecer no checklist antes de uma apresentacao publica dependente do preview.
+
+## Achados
+
+### Bloqueantes
+
+Nenhum bloqueante encontrado.
+
+### Nao bloqueantes / pendencias honestas
+
+1. **Preview Vercel protegido por 401.** A URL do comentario Vercel do PR (`https://sibisc-hub-cultural-git-fix-sibisc-f-b762e3-rafeltrims-projects.vercel.app`) retornou `401` para `/`, `/catalogo/b1` e `/__qa_rota_inexistente_404__`. Por isso, nao foi possivel confirmar no preview que todos os headers configurados em `vercel.json` estao chegando ao navegador nem que a rota inexistente retorna HTTP 404 real.
+2. **Acessibilidade final continua pendente.** O PR corrige estrutura, mas a propria documentacao mantem a necessidade de validacao humana com leitor de tela e contraste formal antes de declarar conformidade.
+3. **Feedback sem GitHub e apenas roteiro local.** A alternativa reduz friccao sem coletar dados sensiveis, mas nao substitui canal institucional definitivo caso o projeto seja exposto para publico nao tecnico.
+
+## Validacao dos bloqueadores
+
+| Item | Resultado | Evidencia |
+| --- | --- | --- |
+| Botao `Buscar` mobile em `/home-mobile` nao interceptado pela bottom nav | Passou | Edge/Playwright em viewport `390x844`: clique em `Buscar` apos selecionar `Eventos de leitura` e preencher `Sapiens` gerou status `Busca aplicada: 1 resultado no catálogo local. Abra um item para ver disponibilidade.` |
+| Catalogo/detalhe deixam disponibilidade mockada clara | Passou | `/catalogo` mostra aviso `Disponibilidade mockada`; cards usam `Disponibilidade demonstrativa do protótipo`; `/catalogo/b1` mostra `Contagem demonstrativa/mockada` e ressalva de que nao executa reserva, retirada ou renovacao oficial. |
+| Acao Renovar nao parece transacao real | Passou | UI usa `Simular renovação`; status pos-clique informa que nenhuma operacao oficial foi enviada a biblioteca. |
+| Jornada nao mostra progresso acima da meta de modo confuso | Passou | `ProgressMeter` limita barra e `aria-valuenow` ao alvo; quando passa da meta, exibe meta concluida e texto complementar com registros reais. |
+| Feedback alternativo nao coleta dados sensiveis | Passou | Template local nao envia dados automaticamente e inclui instrucao explicita para nao incluir dados pessoais sensiveis, tokens, documentos, enderecos completos ou prints privados. |
+| Headers/404 configurados/documentados de forma honesta | Parcial, aceito para merge | `vercel.json` remove catch-all global e define headers; docs declaram que a confirmacao real no Vercel segue pendente. Preview do PR ficou protegido por `401`, impedindo confirmacao externa. |
+| Docs Go/No-Go refletem pendencias reais | Passou | `go_no_go_final_pos_fechamento.md` declara GO apenas para prototipo academico controlado e NO-GO para produto operacional/acessibilidade final. |
+
+## Testes executados
+
+### GitHub/PR
+
+- `gh pr view 62 --json ...`: PR aberto, branch `fix/sibisc-final-closure`, base `main`, `mergeStateStatus: CLEAN`.
+- Checks observados como verdes: `P0 Repository Guard`, `P1 Frontend Build`, `Vercel`, `Vercel Preview Comments`.
+
+### Gates locais
+
+```text
+npm run qa:repo
+QA repository guard passou: estrutura minima, docs, rotas criticas e IDs canonicos estao consistentes.
+```
+
+```text
+npm run qa:ci
+QA repository guard passou: estrutura minima, docs, rotas criticas e IDs canonicos estao consistentes.
+vite v8.0.0 building client environment for production...
+84 modules transformed.
+dist/index.html                  1.00 kB
+dist/assets/index-C82j9rOs.css  61.62 kB
+dist/assets/index-DGsi3R_d.js   321.82 kB
+built in 485ms
+```
+
+### Smoke Playwright/Edge local
+
+Ambiente:
+
+- `vite preview` existente em `http://127.0.0.1:4173`
+- `playwright-cli` via `npx --package @playwright/cli`
+- Browser: `msedge`
+- Viewport mobile: `390x844`
+
+Rotas e asserts:
+
+```text
+/ -> h1 "Feltrim Agents ajuda você a encontrar a próxima leitura."
+/home-mobile -> click Buscar passou; status com 1 resultado para Sapiens
+/catalogo -> contem "Disponibilidade mockada"
+/catalogo/b1 -> contem "Contagem demonstrativa/mockada"
+/perfil -> contem "Perfil demonstrativo" e "Simular renovação"
+/__qa_rota_inexistente_404__ -> UI 404 renderizada com h1 esperado
+```
+
+### Preview Vercel
+
+URL encontrada no comentario Vercel do PR:
+
+```text
+https://sibisc-hub-cultural-git-fix-sibisc-f-b762e3-rafeltrims-projects.vercel.app
+```
+
+Resultado:
+
+```text
+/ -> 401
+/catalogo/b1 -> 401
+/__qa_rota_inexistente_404__ -> 401
+server: Vercel
+x-frame-options: DENY
+```
+
+Conclusao: preview protegido ou inacessivel sem autenticacao. Nao foi possivel validar headers completos nem HTTP 404 real no ambiente Vercel do PR.
+
+## Go/No-Go
+
+**GO para merge:** sim, desde que o merge seja entendido como fechamento do prototipo academico demonstrativo e nao como declaracao de produto operacional.
+
+**NO-GO para afirmar:** integracao real com biblioteca, reserva/renovacao oficial, disponibilidade em tempo real, acessibilidade final, conformidade WCAG ou validacao completa de headers/404 em preview publico.
+
+**Acao recomendada apos merge:** validar o deployment acessivel sem protecao, checar headers completos e confirmar HTTP 404 real para rota inexistente antes da apresentacao publica.

--- a/SIBiSC/docs/qa/sprint_final_fechamento_evidencias.md
+++ b/SIBiSC/docs/qa/sprint_final_fechamento_evidencias.md
@@ -1,0 +1,190 @@
+# Evidencias da sprint final de fechamento - SIBiSC/Feltrim Agents
+
+Data: 2026-05-19  
+Branch: `fix/sibisc-final-closure`  
+Base: `origin/main`  
+Escopo: fechamento dos itens `SF-01` a `SF-09` do plano aprovado.
+
+## Resumo executivo
+
+A sprint final corrigiu os riscos principais de comunicacao operacional: disponibilidade mockada agora aparece junto do catalogo, detalhe e unidades; Perfil informa que os dados sao demonstrativos; a acao de renovacao foi renomeada para simulacao; e a Jornada do leitor nao exibe mais fracoes acima da meta visual.
+
+Tambem foram corrigidos pontos estruturais de acessibilidade, o bug mobile do botao `Buscar` em `/home-mobile`, a alternativa de feedback sem login GitHub, headers de seguranca em `vercel.json` e a configuracao de rotas validas sem catch-all global.
+
+## Evidencia por item
+
+### SF-01 - Disponibilidade mockada clara
+
+Status: corrigido.
+
+- `/catalogo` exibe aviso "Disponibilidade mockada" antes da busca e dos cards.
+- Cards de livro exibem aviso junto da contagem de exemplares.
+- `/catalogo/:id` exibe ressalva junto do total de exemplares, da unidade mais proxima e da disponibilidade por unidade.
+- `AvailabilityTable` atualiza o `aria-label` para explicitar exemplares demonstrativos.
+
+### SF-07 - Renovacao e Perfil demonstrativos
+
+Status: corrigido.
+
+- O topo de `/perfil` informa que nome, e-mail, preferencias, historico, favoritos, emprestimos e notificacoes sao mocks locais.
+- A acao visivel passou de `Renovar` para `Simular renovacao`.
+- O status apos clique informa que nenhuma operacao oficial foi enviada a biblioteca.
+
+### SF-02 - Bottom nav mobile
+
+Status: corrigido e validado localmente.
+
+- `AppLayout` recebeu padding inferior mobile para criar area segura acima da bottom nav fixa.
+- O botao do `SearchField` recebeu `scroll-margin-bottom` para manter alvo acionavel quando focado/rolado.
+- Smoke Playwright/Edge em viewport `390x844` confirmou clique em `Buscar` apos selecionar `Eventos de leitura` e preencher `Sapiens`.
+
+Resultado do smoke:
+
+```text
+/home-mobile search -> clickedBuscar: true
+statusText: Busca aplicada: 1 resultado no catálogo local. Abra um item para ver disponibilidade.
+```
+
+### SF-04 - Acessibilidade estrutural
+
+Status: corrigido.
+
+- `CatalogPage`, `NewsPage` e `EventsPage` usam `SectionHeader` com `headingLevel={1}`.
+- `SectionHeader` preserva `h2` como padrao para secoes internas.
+- A navegacao desktop inclui `Perfil`.
+- Os tres paineis de abas do Perfil permanecem no DOM com `hidden`, eliminando `aria-controls` apontando para elementos inexistentes.
+
+### SF-03 - Leitor de tela real
+
+Status: evidencia honesta criada; validacao real permanece pendente.
+
+Ambiente verificado:
+
+```text
+Narrator.exe: encontrado
+NVDA: nao encontrado no PATH
+```
+
+Decisao: nao foi feita validacao auditiva real nesta sessao, porque a automacao nao oferece canal confiavel para confirmar anuncios, ordem de leitura e comportamento de leitor de tela com uma pessoa usuaria. O roteiro permanece abaixo para execucao assistida antes de qualquer declaracao de acessibilidade final.
+
+Roteiro recomendado:
+
+1. Abrir `/` e navegar por headings e landmarks.
+2. Ativar uma pergunta guiada do Feltrim Agents e confirmar anuncio da regiao `aria-live`.
+3. Buscar `carolina` ou `Sapiens` e confirmar anuncio do status.
+4. Abrir `/catalogo`, entrar em `/catalogo/b1` e verificar leitura dos avisos de disponibilidade demonstrativa.
+5. Abrir `/perfil`, navegar pelas abas por teclado e confirmar estados, nomes e paineis.
+6. Confirmar que `Simular renovacao` e o status resultante nao soam como operacao real.
+7. Repetir em viewport mobile, validando bottom nav e rolagem.
+
+Resultado de release: continua **NO-GO para declarar acessibilidade final/conformidade completa** ate validacao humana com leitor de tela.
+
+### SF-05 - Headers e 404
+
+Status: parcialmente corrigido, com limitacao documentada.
+
+- `vercel.json` passou a configurar:
+  - `Content-Security-Policy` com `frame-ancestors 'none'`;
+  - `X-Content-Type-Options: nosniff`;
+  - `X-Frame-Options: DENY`;
+  - `Referrer-Policy: strict-origin-when-cross-origin`;
+  - `Permissions-Policy` restritiva.
+- O rewrite global `/(.*)` foi removido.
+- Foram mantidos rewrites explicitos para as rotas validas do prototipo e IDs mockados (`b1`-`b8`, `e1`-`e7`, `n1`-`n4`).
+
+Validacao local:
+
+```text
+vercel.json parseado com sucesso
+headers: 1
+rewrites: 8
+hasCatchAll: false
+```
+
+Limitacao: `vite preview` local ainda retorna HTTP 200 para rota inexistente por fallback local da ferramenta, embora a UI 404 renderize corretamente. A confirmacao de HTTP 404 real e headers deve ser feita no deploy preview Vercel, pois `vite preview` nao aplica `vercel.json`.
+
+### SF-08 - Jornada do leitor
+
+Status: corrigido.
+
+- `ProgressMeter` limita `aria-valuenow` e largura visual ao alvo.
+- Valores acima da meta aparecem como `5/5 concluído` e texto complementar, por exemplo `7 registros, meta 5 concluída`.
+- O `aria-label` explicita meta concluida quando aplicavel.
+
+### SF-06 - Feedback sem GitHub
+
+Status: corrigido sem backend.
+
+- Home desktop e mobile mantem GitHub Issues como canal oficial.
+- Foi adicionada alternativa sem login: copiar roteiro local de feedback.
+- A alternativa nao envia dados automaticamente e reforca a instrucao de nao incluir dados pessoais sensiveis.
+
+Decisao: nao foi criado `mailto:` porque nao ha e-mail publico aprovado nos documentos lidos.
+
+### SF-09 - Acabamentos P3
+
+Status: aplicado no escopo seguro.
+
+- Link externo de noticia usa `rel="noopener noreferrer"`.
+- Microcopy pontual foi ajustada em catalogo, Perfil, feedback e Jornada.
+- Contraste formal com ferramenta dedicada nao foi medido nesta sessao; permanece pendencia antes de declaracao WCAG.
+
+## Validacoes executadas
+
+### Diagnosticos de editor
+
+Resultado: sem erros nos arquivos editados via `ReadLints`.
+
+### `npm run qa:repo`
+
+Primeira execucao: falhou porque o guard textual exigia a frase historica sem acentos no aviso de privacidade.  
+Acao: preservado o contrato do guard em `SOFIA_CLAUDIA_PRIVACY_NOTICE`.
+
+Resultado final:
+
+```text
+QA repository guard passou: estrutura minima, docs, rotas criticas e IDs canonicos estao consistentes.
+```
+
+### `npm run qa:ci`
+
+Resultado final:
+
+```text
+QA repository guard passou: estrutura minima, docs, rotas criticas e IDs canonicos estao consistentes.
+vite v8.0.0 building client environment for production...
+84 modules transformed.
+dist/index.html 1.00 kB
+dist/assets/index-C82j9rOs.css 61.62 kB
+dist/assets/index-DGsi3R_d.js 321.82 kB
+built in 923ms
+```
+
+### Smoke Playwright/Edge
+
+Ambiente:
+
+- `npm run preview -- --host 127.0.0.1 --port 4173`
+- `playwright-cli` com `--browser msedge`
+- viewport `390x844`
+
+Rotas verificadas:
+
+```text
+/ -> 200, renderizado
+/home-mobile -> 200, renderizado
+/catalogo -> 200, renderizado
+/catalogo/b1 -> 200, renderizado
+/perfil -> 200, renderizado
+/__qa_rota_inexistente_404__ -> 200 local, UI 404 renderizada
+/home-mobile search -> clickedBuscar true
+```
+
+Observacao: o status HTTP 200 da rota inexistente e resultado do preview local, nao do deploy Vercel com `vercel.json`.
+
+## Pendencias remanescentes
+
+- Executar validacao humana real com Narrator/NVDA antes de declarar acessibilidade final.
+- Confirmar headers e HTTP 404 real no deploy preview Vercel/PR.
+- Medir contraste formalmente antes de qualquer declaracao WCAG AA.
+- Rafael deve aprovar o canal definitivo de feedback sem GitHub caso queira algo alem do roteiro local.

--- a/SIBiSC/src/components/cards/BookCard.jsx
+++ b/SIBiSC/src/components/cards/BookCard.jsx
@@ -18,6 +18,7 @@ function BookCard({ book, selectedNeighborhood = 'Centro' }) {
       </div>
       <div className={styles.footer}>
         <strong>{availabilityLabel}</strong>
+        <small>Disponibilidade demonstrativa do protótipo; confirme com a biblioteca antes de se deslocar.</small>
         {nearestInventory ? (
           <span>
             {nearestInventory.unit.name}, {nearestInventory.distanceByNeighborhood[effectiveNeighborhood]} de distância

--- a/SIBiSC/src/components/cards/BookCard.module.css
+++ b/SIBiSC/src/components/cards/BookCard.module.css
@@ -56,6 +56,12 @@
   font-size: 1rem;
 }
 
+.footer small {
+  color: var(--color-ink-soft);
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
 .footer span {
   color: var(--color-ink-soft);
   font-size: 0.88rem;

--- a/SIBiSC/src/components/layout/AppLayout.jsx
+++ b/SIBiSC/src/components/layout/AppLayout.jsx
@@ -9,6 +9,7 @@ const desktopItems = [
   { to: '/noticias', label: 'Notícias' },
   { to: '/eventos', label: 'Eventos' },
   { to: '/catalogo', label: 'Catálogo' },
+  { to: '/perfil', label: 'Perfil' },
 ];
 
 const headlineFacts = ['4 unidades conectadas', 'agenda cultural viva', 'acervo com busca rápida'];

--- a/SIBiSC/src/components/layout/AppLayout.module.css
+++ b/SIBiSC/src/components/layout/AppLayout.module.css
@@ -297,6 +297,10 @@
     padding: 0.65rem 0;
   }
 
+  .main {
+    padding-bottom: calc(6.5rem + env(safe-area-inset-bottom));
+  }
+
   .footer {
     margin-top: var(--space-xl);
     margin-bottom: calc(4.8rem + env(safe-area-inset-bottom));

--- a/SIBiSC/src/components/ui/AvailabilityTable.jsx
+++ b/SIBiSC/src/components/ui/AvailabilityTable.jsx
@@ -16,7 +16,7 @@ function AvailabilityTable({ inventory, selectedNeighborhood }) {
             </div>
             <span
               className={styles.stock}
-              aria-label={`${item.available} de ${item.total} exemplares ${item.available > 0 ? 'disponíveis' : 'indisponíveis'}`}
+              aria-label={`${item.available} de ${item.total} exemplares demonstrativos ${item.available > 0 ? 'disponíveis' : 'indisponíveis'}`}
             >
               {item.available}/{item.total}
             </span>
@@ -25,7 +25,11 @@ function AvailabilityTable({ inventory, selectedNeighborhood }) {
             <code>{item.callNumber}</code>
             <span>{item.shelf}</span>
           </div>
-          <p>{item.available > 0 ? 'Disponível para retirada no protótipo local.' : 'Sem exemplares disponíveis nesta unidade.'}</p>
+          <p>
+            {item.available > 0
+              ? 'Disponibilidade demonstrativa do protótipo; confirme retirada e estoque real com a biblioteca.'
+              : 'Sem exemplares disponíveis nesta unidade no inventário demonstrativo.'}
+          </p>
           <p>{item.unit.hours}</p>
         </article>
       ))}

--- a/SIBiSC/src/components/ui/SearchField.module.css
+++ b/SIBiSC/src/components/ui/SearchField.module.css
@@ -59,6 +59,7 @@
   background: linear-gradient(135deg, var(--color-accent), var(--color-accent-strong));
   box-shadow: var(--shadow-soft);
   font-weight: 800;
+  scroll-margin-bottom: calc(6rem + env(safe-area-inset-bottom));
 }
 
 .status {

--- a/SIBiSC/src/components/ui/SectionHeader.jsx
+++ b/SIBiSC/src/components/ui/SectionHeader.jsx
@@ -1,12 +1,14 @@
 ﻿import { Link } from 'react-router-dom';
 import styles from './SectionHeader.module.css';
 
-function SectionHeader({ eyebrow, title, description, linkTo, linkLabel }) {
+function SectionHeader({ eyebrow, title, description, linkTo, linkLabel, headingLevel = 2 }) {
+  const HeadingTag = headingLevel === 1 ? 'h1' : 'h2';
+
   return (
     <div className={styles.wrap}>
       <div>
         {eyebrow ? <span className={styles.eyebrow}>{eyebrow}</span> : null}
-        <h2>{title}</h2>
+        <HeadingTag>{title}</HeadingTag>
         {description ? <p>{description}</p> : null}
       </div>
       {linkTo && linkLabel ? (

--- a/SIBiSC/src/components/ui/SectionHeader.module.css
+++ b/SIBiSC/src/components/ui/SectionHeader.module.css
@@ -19,6 +19,7 @@
   text-transform: uppercase;
 }
 
+.wrap h1,
 .wrap h2 {
   font-size: clamp(1.8rem, 4vw, 2.7rem);
 }

--- a/SIBiSC/src/pages/BookDetailPage.jsx
+++ b/SIBiSC/src/pages/BookDetailPage.jsx
@@ -83,7 +83,10 @@ function BookDetailPage() {
           <h1>{book.title}</h1>
           <p>{book.author}</p>
         </div>
-        <strong className={styles.availability}>{book.totalAvailable} exemplares disponíveis</strong>
+        <div className={styles.availabilityBox}>
+          <strong className={styles.availability}>{book.totalAvailable} exemplares disponíveis</strong>
+          <p>Contagem demonstrativa/mockada; confirme disponibilidade real com a biblioteca.</p>
+        </div>
       </div>
 
       <div className={styles.metaGrid}>
@@ -133,11 +136,15 @@ function BookDetailPage() {
           <span>
             {nearestInventory.distanceByNeighborhood[selectedNeighborhood]} de distância, chamada {nearestInventory.callNumber}, {nearestInventory.shelf}
           </span>
+          <small>Unidade sugerida apenas com base no inventário local do protótipo.</small>
         </div>
       ) : null}
 
       <div>
         <h2>Disponibilidade por unidade</h2>
+        <p className={styles.mockNotice}>
+          Os dados abaixo são demonstrativos e não executam reserva, retirada ou renovação oficial.
+        </p>
         <AvailabilityTable inventory={book.inventory} selectedNeighborhood={selectedNeighborhood} />
       </div>
     </article>

--- a/SIBiSC/src/pages/BookDetailPage.module.css
+++ b/SIBiSC/src/pages/BookDetailPage.module.css
@@ -34,12 +34,27 @@
   font-size: clamp(2rem, 4vw, 3.2rem);
 }
 
+.availabilityBox {
+  display: grid;
+  gap: 0.35rem;
+  max-width: 19rem;
+}
+
 .availability {
   align-self: start;
+  width: fit-content;
   padding: 0.65rem 0.9rem;
   border-radius: var(--radius-pill);
   color: var(--color-success);
   background: rgba(47, 123, 87, 0.1);
+}
+
+.availabilityBox p,
+.highlight small,
+.mockNotice {
+  color: var(--color-ink-soft);
+  font-size: 0.84rem;
+  line-height: 1.45;
 }
 
 .metaGrid {
@@ -91,4 +106,8 @@
 
 .highlight span {
   color: var(--color-ink-soft);
+}
+
+.mockNotice {
+  margin: var(--space-xs) 0 var(--space-md);
 }

--- a/SIBiSC/src/pages/CatalogPage.jsx
+++ b/SIBiSC/src/pages/CatalogPage.jsx
@@ -96,8 +96,17 @@ function CatalogPage() {
       <SectionHeader
         eyebrow="Acervo"
         title="Catálogo"
-        description="Busque livros por título, autor ou ISBN e descubra onde retirar o exemplar."
+        description="Busque livros por título, autor ou ISBN e veja uma prévia demonstrativa de unidades."
+        headingLevel={1}
       />
+
+      <aside className={styles.mockNotice} aria-label="Aviso sobre disponibilidade demonstrativa">
+        <strong>Disponibilidade mockada</strong>
+        <p>
+          Os números de exemplares e unidades são dados locais do protótipo. Confirme estoque,
+          retirada e regras oficiais diretamente com a biblioteca antes de se deslocar.
+        </p>
+      </aside>
 
       <SearchField
         label="Buscar no catálogo"
@@ -142,7 +151,7 @@ function CatalogPage() {
         </div>
       ) : null}
 
-      {loading ? <LoadingState label="Consultando disponibilidade no catalogo..." /> : null}
+      {loading ? <LoadingState label="Consultando disponibilidade no catálogo..." /> : null}
 
       {!loading && !loadError && books.length ? (
         <div className={styles.results} data-testid="catalog-results">

--- a/SIBiSC/src/pages/CatalogPage.module.css
+++ b/SIBiSC/src/pages/CatalogPage.module.css
@@ -1,4 +1,23 @@
-﻿.geoFallback {
+﻿.mockNotice {
+  display: grid;
+  gap: 0.35rem;
+  margin-bottom: var(--space-lg);
+  padding: var(--space-md);
+  border: 1px solid rgba(210, 100, 56, 0.24);
+  border-radius: var(--radius-md);
+  background: rgba(210, 100, 56, 0.08);
+}
+
+.mockNotice strong {
+  color: var(--color-accent-strong);
+}
+
+.mockNotice p {
+  color: var(--color-ink-soft);
+  font-size: 0.92rem;
+}
+
+.geoFallback {
   display: grid;
   gap: var(--space-md);
   margin-top: var(--space-lg);

--- a/SIBiSC/src/pages/EventsPage.jsx
+++ b/SIBiSC/src/pages/EventsPage.jsx
@@ -57,6 +57,7 @@ function EventsPage() {
         eyebrow="Agenda cultural"
         title="Eventos"
         description="Oficinas, encontros, clubes de leitura e atividades distribuídas pela rede."
+        headingLevel={1}
       />
 
       {loadError ? <ErrorState title="Agenda indisponível" message={loadError} /> : null}

--- a/SIBiSC/src/pages/HomePage.jsx
+++ b/SIBiSC/src/pages/HomePage.jsx
@@ -19,6 +19,7 @@ import {
 import {
   SOFIA_CLAUDIA_FEEDBACK_FLOW,
   SOFIA_CLAUDIA_FEEDBACK_ISSUE_URL,
+  SOFIA_CLAUDIA_FEEDBACK_TEMPLATE,
   SOFIA_CLAUDIA_PRIVACY_NOTICE,
 } from '../services/feedbackService';
 import useDebouncedValue from '../hooks/useDebouncedValue';
@@ -71,6 +72,7 @@ function HomePage() {
   const [assistantRecommendations, setAssistantRecommendations] = useState([]);
   const [query, setQuery] = useState('');
   const [searchStatus, setSearchStatus] = useState('');
+  const [feedbackCopyStatus, setFeedbackCopyStatus] = useState('');
   const [selectedGuideId, setSelectedGuideId] = useState(guidedAssistantQuestions[0].id);
   const debouncedQuery = useDebouncedValue(query, 180);
 
@@ -143,6 +145,15 @@ function HomePage() {
         ? `Feltrim Agents encontrou ${countLabel} no catálogo local. Abra um resultado para ver disponibilidade.`
         : 'Feltrim Agents não encontrou uma sugestão segura no catálogo local. Tente outro termo ou explore o catálogo completo.'
     );
+  }
+
+  async function handleCopyFeedbackTemplate() {
+    try {
+      await navigator.clipboard.writeText(SOFIA_CLAUDIA_FEEDBACK_TEMPLATE);
+      setFeedbackCopyStatus('Roteiro de feedback copiado. Cole em um documento ou entregue durante a apresentação.');
+    } catch {
+      setFeedbackCopyStatus('Não foi possível copiar automaticamente. Use o roteiro exibido nesta seção.');
+    }
   }
 
   if (loading) {
@@ -376,6 +387,25 @@ function HomePage() {
         >
           Enviar feedback via GitHub Issues
         </a>
+        <div className={styles.feedbackAlternative}>
+          <strong>Sem conta GitHub?</strong>
+          <p>
+            Copie um roteiro local de feedback e entregue ao grupo durante a apresentação. Ele não envia dados
+            automaticamente nem depende de login.
+          </p>
+          <button type="button" onClick={handleCopyFeedbackTemplate}>
+            Copiar roteiro de feedback
+          </button>
+          <details>
+            <summary>Ver roteiro</summary>
+            <pre>{SOFIA_CLAUDIA_FEEDBACK_TEMPLATE}</pre>
+          </details>
+          {feedbackCopyStatus ? (
+            <p className={styles.feedbackCopyStatus} role="status" aria-live="polite">
+              {feedbackCopyStatus}
+            </p>
+          ) : null}
+        </div>
       </section>
 
       <section>

--- a/SIBiSC/src/pages/HomePage.module.css
+++ b/SIBiSC/src/pages/HomePage.module.css
@@ -848,6 +848,56 @@
   outline-offset: 3px;
 }
 
+.feedbackAlternative {
+  display: grid;
+  gap: 0.6rem;
+  padding: 0.85rem;
+  border-radius: var(--radius-sm);
+  background: rgba(18, 38, 63, 0.06);
+}
+
+.feedbackAlternative strong {
+  color: var(--color-ink);
+}
+
+.feedbackAlternative p {
+  margin: 0;
+  font-size: 0.86rem;
+}
+
+.feedbackAlternative button {
+  justify-self: start;
+  min-height: 2.5rem;
+  padding: 0 0.85rem;
+  border: 1px solid rgba(210, 100, 56, 0.24);
+  border-radius: var(--radius-pill);
+  color: var(--color-accent-strong);
+  background: white;
+  font-weight: 800;
+}
+
+.feedbackAlternative summary {
+  cursor: pointer;
+  color: var(--color-accent-strong);
+  font-weight: 800;
+}
+
+.feedbackAlternative pre {
+  overflow-x: auto;
+  margin-top: 0.55rem;
+  padding: 0.75rem;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--color-ink);
+  font-size: 0.78rem;
+  white-space: pre-wrap;
+}
+
+.feedbackCopyStatus {
+  color: var(--color-success) !important;
+  font-weight: 800;
+}
+
 .grid,
 .eventGrid {
   display: grid;

--- a/SIBiSC/src/pages/HomePageMobile.jsx
+++ b/SIBiSC/src/pages/HomePageMobile.jsx
@@ -21,6 +21,7 @@ import {
 } from '../services/guidedAssistantService';
 import {
   SOFIA_CLAUDIA_FEEDBACK_ISSUE_URL,
+  SOFIA_CLAUDIA_FEEDBACK_TEMPLATE,
   SOFIA_CLAUDIA_PRIVACY_NOTICE,
 } from '../services/feedbackService';
 
@@ -47,6 +48,7 @@ function HomePageMobile() {
   const [profile, setProfile] = useState(null);
   const [query, setQuery] = useState('');
   const [searchStatus, setSearchStatus] = useState('');
+  const [feedbackCopyStatus, setFeedbackCopyStatus] = useState('');
   const [selectedGuideId, setSelectedGuideId] = useState(guidedAssistantQuestions[0].id);
   const debouncedQuery = useDebouncedValue(query, 180);
 
@@ -112,6 +114,15 @@ function HomePageMobile() {
         ? `Busca aplicada: ${countLabel} no catálogo local. Abra um item para ver disponibilidade.`
         : 'Busca aplicada: nenhum item seguro no catálogo local. Tente outro termo ou abra o catálogo completo.'
     );
+  }
+
+  async function handleCopyFeedbackTemplate() {
+    try {
+      await navigator.clipboard.writeText(SOFIA_CLAUDIA_FEEDBACK_TEMPLATE);
+      setFeedbackCopyStatus('Roteiro copiado para compartilhar sem login GitHub.');
+    } catch {
+      setFeedbackCopyStatus('Copie manualmente o roteiro exibido nesta seção.');
+    }
   }
 
   if (loading) {
@@ -261,6 +272,22 @@ function HomePageMobile() {
         >
           Enviar feedback
         </a>
+        <div className={styles.feedbackAlternative}>
+          <strong>Sem GitHub?</strong>
+          <p>Copie um roteiro local e entregue ao grupo durante a apresentação, sem envio automático.</p>
+          <button type="button" onClick={handleCopyFeedbackTemplate}>
+            Copiar roteiro
+          </button>
+          <details>
+            <summary>Ver roteiro</summary>
+            <pre>{SOFIA_CLAUDIA_FEEDBACK_TEMPLATE}</pre>
+          </details>
+          {feedbackCopyStatus ? (
+            <p className={styles.feedbackCopyStatus} role="status" aria-live="polite">
+              {feedbackCopyStatus}
+            </p>
+          ) : null}
+        </div>
       </section>
 
       {/* Quick Actions */}

--- a/SIBiSC/src/pages/HomePageMobile.module.css
+++ b/SIBiSC/src/pages/HomePageMobile.module.css
@@ -279,6 +279,57 @@
   outline-offset: 3px;
 }
 
+.feedbackAlternative {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.72rem;
+  border-radius: var(--radius-sm);
+  background: rgba(16, 37, 63, 0.05);
+}
+
+.feedbackAlternative strong {
+  color: var(--color-ink);
+  font-size: 0.86rem;
+}
+
+.feedbackAlternative p {
+  margin: 0;
+  font-size: 0.82rem;
+}
+
+.feedbackAlternative button {
+  justify-self: start;
+  min-height: 2.35rem;
+  padding: 0 0.78rem;
+  border: 1px solid rgba(210, 100, 56, 0.24);
+  border-radius: var(--radius-pill);
+  color: var(--color-accent-strong);
+  background: white;
+  font-weight: 800;
+}
+
+.feedbackAlternative summary {
+  cursor: pointer;
+  color: var(--color-accent-strong);
+  font-weight: 800;
+}
+
+.feedbackAlternative pre {
+  overflow-x: auto;
+  margin-top: 0.5rem;
+  padding: 0.65rem;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--color-ink);
+  font-size: 0.72rem;
+  white-space: pre-wrap;
+}
+
+.feedbackCopyStatus {
+  color: var(--color-success) !important;
+  font-weight: 800;
+}
+
 /* Quick Actions */
 .quickActions {
   display: grid;

--- a/SIBiSC/src/pages/NewsDetailPage.jsx
+++ b/SIBiSC/src/pages/NewsDetailPage.jsx
@@ -81,7 +81,7 @@ function NewsDetailPage() {
           <a
             className={styles.sourceLink}
             href={item.sourceUrl}
-            rel="noreferrer"
+            rel="noopener noreferrer"
             target="_blank"
           >
             {item.sourceLabel}

--- a/SIBiSC/src/pages/NewsPage.jsx
+++ b/SIBiSC/src/pages/NewsPage.jsx
@@ -67,6 +67,7 @@ function NewsPage() {
         eyebrow="Editorial"
         title="Notícias"
         description="Atualizações sobre serviços, eventos, inclusão e circulação do acervo."
+        headingLevel={1}
       />
       <FilterPills
         options={categories}

--- a/SIBiSC/src/pages/UserProfilePage.jsx
+++ b/SIBiSC/src/pages/UserProfilePage.jsx
@@ -18,24 +18,28 @@ import {
 } from '../services/userProfileService';
 
 function ProgressMeter({ label, progress, target, progressPercent }) {
+  const isComplete = progress >= target;
+  const clampedProgress = Math.min(progress, target);
+  const displayValue = isComplete ? `${target}/${target} concluído` : `${progress}/${target}`;
+  const statusText = isComplete && progress > target ? `${progress} registros, meta ${target} concluída.` : '';
+
   return (
     <div className={styles.progressMeter}>
       <div className={styles.progressMeta}>
         <span>{label}</span>
-        <strong>
-          {progress}/{target}
-        </strong>
+        <strong>{displayValue}</strong>
       </div>
       <div
         className={styles.progressTrack}
         role="progressbar"
-        aria-label={`${label}: ${progress} de ${target}`}
+        aria-label={`${label}: ${progress} de ${target}${isComplete ? ', meta concluída' : ''}`}
         aria-valuemin="0"
         aria-valuemax={target}
-        aria-valuenow={Math.min(progress, target)}
+        aria-valuenow={clampedProgress}
       >
-        <span style={{ width: `${progressPercent}%` }} />
+        <span style={{ width: `${Math.min(progressPercent, 100)}%` }} />
       </div>
+      {statusText ? <small className={styles.progressComplete}>{statusText}</small> : null}
     </div>
   );
 }
@@ -124,7 +128,9 @@ function UserProfilePage() {
       setLoans((currentLoans) =>
         currentLoans.map((item) => (item.id === renewedLoan.id ? { ...renewedLoan } : item))
       );
-      setActionStatus(`Empréstimo renovado: ${loan?.title ?? 'livro selecionado'}. Confira a nova data de devolução.`);
+      setActionStatus(
+        `Renovação demonstrativa simulada para ${loan?.title ?? 'livro selecionado'}. Nenhuma operação oficial foi enviada à biblioteca.`
+      );
       return;
     } catch {
       setActionStatus('Não foi possível renovar este empréstimo no protótipo.');
@@ -162,6 +168,14 @@ function UserProfilePage() {
     <div className={styles.container}>
       {/* User Header */}
       <section className={styles.userHeader}>
+        <div className={styles.prototypeNotice} role="note">
+          <strong>Perfil demonstrativo</strong>
+          <p>
+            Nome, e-mail, preferências, histórico, favoritos, empréstimos e notificações são mocks locais
+            para apresentação. Não há dados pessoais reais, persistência ou operação oficial de biblioteca.
+          </p>
+        </div>
+
         <div className={styles.userCard}>
           <div className={styles.avatar} role="img" aria-label={`Perfil de ${user.name}`}>
             {user.avatar}
@@ -311,13 +325,13 @@ function UserProfilePage() {
       </div>
 
       {/* Tab Content - Empréstimos Ativos */}
-      {activeTab === 'reservas' && (
-        <section
-          id="profile-panel-loans"
-          className={styles.tabContent}
-          role="tabpanel"
-          aria-labelledby="profile-tab-loans"
-        >
+      <section
+        id="profile-panel-loans"
+        className={styles.tabContent}
+        role="tabpanel"
+        aria-labelledby="profile-tab-loans"
+        hidden={activeTab !== 'reservas'}
+      >
           <div className={styles.stack}>
             {loans.map((loan) => {
               const daysLeft = daysUntilDue(loan.dueDate);
@@ -351,26 +365,25 @@ function UserProfilePage() {
                       type="button"
                       className={styles.renewBtn}
                       onClick={() => handleRenew(loan.id)}
-                      title="Renovar empréstimo por mais 14 dias"
+                      title="Simular renovação demonstrativa por mais 14 dias"
                     >
-                      Renovar
+                      Simular renovação
                     </button>
                   )}
                 </div>
               );
             })}
           </div>
-        </section>
-      )}
+      </section>
 
       {/* Tab Content - Histórico */}
-      {activeTab === 'historico' && (
-        <section
-          id="profile-panel-history"
-          className={styles.tabContent}
-          role="tabpanel"
-          aria-labelledby="profile-tab-history"
-        >
+      <section
+        id="profile-panel-history"
+        className={styles.tabContent}
+        role="tabpanel"
+        aria-labelledby="profile-tab-history"
+        hidden={activeTab !== 'historico'}
+      >
           <div className={styles.timeline}>
             {loanHistory.map((item) => (
               <Link
@@ -395,17 +408,16 @@ function UserProfilePage() {
               </Link>
             ))}
           </div>
-        </section>
-      )}
+      </section>
 
       {/* Tab Content - Favoritos */}
-      {activeTab === 'favoritos' && (
-        <section
-          id="profile-panel-favorites"
-          className={styles.tabContent}
-          role="tabpanel"
-          aria-labelledby="profile-tab-favorites"
-        >
+      <section
+        id="profile-panel-favorites"
+        className={styles.tabContent}
+        role="tabpanel"
+        aria-labelledby="profile-tab-favorites"
+        hidden={activeTab !== 'favoritos'}
+      >
           {favorites.length > 0 ? (
             <div className={styles.favoritesList}>
               {favorites.map((fav) => (
@@ -422,8 +434,8 @@ function UserProfilePage() {
                           }`}
                         >
                           {fav.available
-                            ? `Disponível: ${fav.availableCount} de ${fav.totalCount}`
-                            : `Indisponível: ${fav.totalCount} exemplares`}
+                            ? `Demo: ${fav.availableCount} de ${fav.totalCount}`
+                            : `Demo: indisponível (${fav.totalCount})`}
                         </div>
                         {fav.lastBorrowed && (
                           <p className={styles.lastBorrowed}>
@@ -452,8 +464,7 @@ function UserProfilePage() {
               </Link>
             </div>
           )}
-        </section>
-      )}
+      </section>
     </div>
   );
 }

--- a/SIBiSC/src/pages/UserProfilePage.module.css
+++ b/SIBiSC/src/pages/UserProfilePage.module.css
@@ -15,6 +15,25 @@
   margin-top: var(--space-sm);
 }
 
+.prototypeNotice {
+  display: grid;
+  gap: 0.35rem;
+  padding: var(--space-md);
+  border: 1px solid rgba(210, 100, 56, 0.24);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.prototypeNotice strong {
+  color: var(--color-accent-strong);
+}
+
+.prototypeNotice p {
+  color: var(--color-ink-soft);
+  font-size: 0.86rem;
+  line-height: 1.5;
+}
+
 .userCard {
   display: grid;
   grid-template-columns: auto 1fr;
@@ -265,6 +284,13 @@
   height: 100%;
   border-radius: inherit;
   background: linear-gradient(90deg, var(--color-accent), var(--color-highlight));
+}
+
+.progressComplete {
+  color: var(--color-success);
+  font-size: 0.74rem;
+  font-weight: 700;
+  line-height: 1.35;
 }
 
 /* Tabs Navigation */

--- a/SIBiSC/src/services/feedbackService.js
+++ b/SIBiSC/src/services/feedbackService.js
@@ -4,8 +4,19 @@ export const SOFIA_CLAUDIA_FEEDBACK_ISSUE_URL =
 export const SOFIA_CLAUDIA_PRIVACY_NOTICE =
   'Nao envie dados pessoais sensiveis, tokens, documentos, enderecos completos ou prints com informacoes privadas.';
 
+export const SOFIA_CLAUDIA_FEEDBACK_TEMPLATE = `Feedback SIBiSC/Feltrim Agents
+
+Rota ou tela:
+Dispositivo/navegador:
+O que eu tentei fazer:
+O que aconteceu:
+O que eu esperava:
+Impacto percebido:
+
+Privacidade: não inclua dados pessoais sensíveis, tokens, documentos, endereços completos ou prints privados.`;
+
 export const SOFIA_CLAUDIA_FEEDBACK_FLOW = [
-  'Sofia classifica o impacto percebido e a clareza da experiencia.',
-  'Claudia registra rota, dispositivo, passos, evidencias, status e SLA.',
+  'Sofia classifica o impacto percebido e a clareza da experiência.',
+  'Claudia registra rota, dispositivo, passos, evidências, status e SLA.',
   'QA reproduz o caso antes de produto priorizar ou fechar o feedback.',
 ];

--- a/SIBiSC/vercel.json
+++ b/SIBiSC/vercel.json
@@ -3,9 +3,64 @@
   "framework": "vite",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "rewrites": [
+  "headers": [
     {
       "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.supabase.co"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=()"
+        }
+      ]
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/home-mobile",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/noticias",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/noticias/:newsId(n1|n2|n3|n4)",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/eventos",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/eventos/:eventId(e1|e2|e3|e4|e5|e6|e7)",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/catalogo",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/catalogo/:bookId(b1|b2|b3|b4|b5|b6|b7|b8)",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/perfil",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
## Summary
- Fecha os P1/P2 da sprint final com avisos de disponibilidade mockada, Perfil/renovação demonstrativos, correção do CTA mobile e acessibilidade estrutural.
- Adiciona feedback alternativo sem GitHub login por roteiro local copiável e endurece `vercel.json` com headers e rewrites explícitos.
- Registra evidências finais e Go/No-Go pós-fechamento, incluindo limitações de leitor de tela, contraste e confirmação de headers/404 em Vercel.

## Test plan
- [x] ReadLints nos arquivos editados
- [x] `npm run qa:repo`
- [x] `npm run qa:ci`
- [x] Smoke Playwright/Edge local em `/`, `/home-mobile`, `/catalogo`, `/catalogo/b1`, `/perfil`, rota inexistente e clique `Buscar` mobile
- [x] Parse/checagem local de `vercel.json`

## Pendências documentadas
- Validar headers e HTTP 404 real no deploy preview Vercel, já que `vite preview` não aplica `vercel.json`.
- Executar validação humana com Narrator/NVDA antes de declarar acessibilidade final.
- Medir contraste formalmente antes de qualquer declaração WCAG.

Made with [Cursor](https://cursor.com)