### PR TITLE
Close SIBiSC final a11y and security polish

### DIFF
--- a/SIBiSC/docs/product/go_no_go_final_pos_fechamento.md
+++ b/SIBiSC/docs/product/go_no_go_final_pos_fechamento.md
@@ -1,8 +1,8 @@
 # Go/No-Go final pos-fechamento - SIBiSC/Feltrim Agents
 
 Data: 2026-05-19  
-Branch: `fix/sibisc-final-closure`  
-Documento de evidencias: `SIBiSC/docs/qa/sprint_final_fechamento_evidencias.md`  
+Branch: `fix/sibisc-final-a11y-security-polish`  
+Documento de evidencias: `SIBiSC/docs/qa/final_a11y_security_polish.md`  
 Validacao assistiva Sofia: `SIBiSC/docs/qa/validacao_leitor_tela_sofia.md`
 
 ## Decisao executiva
@@ -28,10 +28,10 @@ Foram corrigidos `h1`, descoberta do Perfil e `aria-controls` das abas. Por deci
 | SF-02 bottom nav mobile | Corrigido | Smoke confirmou clique no `Buscar` em `/home-mobile`. |
 | SF-04 acessibilidade estrutural | Corrigido | `h1`, Perfil desktop e paineis de tabs ajustados. |
 | SF-03 leitor de tela | Aprovado com ressalvas | Sofia validou como leitora de tela real por decisao do Rafael; sem declarar execucao auditiva de NVDA/Narrator/VoiceOver. |
-| SF-05 headers/404 | Parcial corrigido | Headers e rewrites Vercel implementados; confirmar em preview Vercel. |
+| SF-05 headers/404 | Corrigido em configuracao, validacao remota pendente | Root `vercel.json`, `SIBiSC/vercel.json` e `netlify.toml` incluem headers defensivos; rewrites/redirects foram restringidos a rotas conhecidas para permitir 404 real no host estatico. Confirmar em preview/deploy Vercel. |
 | SF-08 Jornada do leitor | Corrigido | Progresso acima da meta aparece como meta concluida. |
 | SF-06 feedback alternativo | Corrigido | Roteiro local copiavel sem GitHub login. |
-| SF-09 acabamentos P3 | Parcial corrigido | `noopener noreferrer` e microcopy; contraste formal pendente. |
+| SF-09 acabamentos P3 | Parcial corrigido | `noopener noreferrer`, microcopy e reforco visual de contraste/foco; medicao formal completa de contraste ainda pendente. |
 
 ## Validacoes finais locais
 
@@ -41,6 +41,7 @@ Foram corrigidos `h1`, descoberta do Perfil e `aria-controls` das abas. Por deci
 - Smoke Playwright/Edge: passou nas rotas `/`, `/home-mobile`, `/catalogo`, `/catalogo/b1`, `/perfil` e UI 404 de rota inexistente.
 - Caso mobile critico: `Eventos de leitura` + `Sapiens` + clique em `Buscar` passou.
 - Validacao Sofia/leitor de tela real: passou com ressalvas em `/`, `/home-mobile`, `/catalogo`, `/catalogo/b1`, `/perfil`, `/eventos` e rota inexistente.
+- Atualizacao SF-FINAL-01 a SF-FINAL-04: `ReadLints`, `npm run qa:repo`, `npm run qa:ci` e smoke Playwright em Microsoft Edge passaram; `vite preview` segue retornando `200` para rota inexistente por fallback local, entao HTTP 404 real e headers devem ser confirmados no preview/deploy remoto.
 
 ## Ressalvas para apresentacao
 

--- a/SIBiSC/docs/qa/final_a11y_security_polish.md
+++ b/SIBiSC/docs/qa/final_a11y_security_polish.md
@@ -73,11 +73,13 @@ No smoke mobile, a ordem inicial de foco ficou: skip link, marca, Início, Notí
   - `/perfil`: `200`, h1 `João Silva`
   - `/__sf_final_rota_inexistente__`: `200` local, UI 404 com h1 `Essa rota ainda não existe no mapa do SIBiSC.`
   - console Edge: 0 errors, 0 warnings.
+- PR #63: checks iniciais passaram (`P0 Repository Guard`, `P1 Frontend Build`, `Vercel`, `Vercel Preview Comments`).
+- Tentativa de validacao HTTP direta no preview Vercel do PR retornou `401 Unauthorized` para `/`, `/home-mobile`, `/catalogo`, `/catalogo/b1`, `/perfil` e rota inexistente. Portanto, os headers finais e o HTTP 404 real continuam como validacao remota pendente em ambiente publicamente acessivel ou com autenticacao de preview liberada.
 
 ## Pendencias reais
 
-- Confirmar no preview/deploy Vercel que os headers estao presentes no dominio efetivo.
-- Confirmar no preview/deploy Vercel que rota inexistente retorna HTTP 404 real.
+- Confirmar no preview/deploy Vercel publicamente acessivel, ou com autenticacao de preview liberada, que os headers estao presentes no dominio efetivo.
+- Confirmar no preview/deploy Vercel publicamente acessivel, ou com autenticacao de preview liberada, que rota inexistente retorna HTTP 404 real.
 - Se houver deploy Netlify, confirmar que os redirects explicitos preservam deep links validos e deixam rotas desconhecidas em 404.
 - Fazer medicao manual completa de contraste em gradientes/pseudo-elementos antes de declarar conformidade WCAG AA completa.
 - Manter NO-GO para produto operacional real, reserva/renovacao oficial, integracao com biblioteca e compatibilidade auditada com NVDA/Narrator/VoiceOver ate validacoes dedicadas.

--- a/SIBiSC/docs/qa/final_a11y_security_polish.md
+++ b/SIBiSC/docs/qa/final_a11y_security_polish.md
@@ -1,0 +1,83 @@
+# Polimento final de acessibilidade, headers e 404 - SIBiSC/Feltrim Agents
+
+Data: 2026-05-19  
+Branch: `fix/sibisc-final-a11y-security-polish`  
+Escopo: `SF-FINAL-01` a `SF-FINAL-04`
+
+## Resumo executivo
+
+Foram aplicadas correcoes finais seguras para reduzir as pendencias P2 de hardening e acessibilidade do prototipo academico. A configuracao efetiva no root do projeto agora inclui headers defensivos e deixou de usar rewrite global de SPA; os hosts estaticos passam a reescrever apenas rotas conhecidas para `index.html`, permitindo 404 real para rotas desconhecidas no deploy.
+
+O layout recebeu skip link, alvo `main` focavel, landmarks mais claros, footer rotulado e bottom nav mobile movida para mais cedo no DOM sem mudar seu comportamento visual fixo. O contraste foi reforcado nos pontos de maior risco visual: tokens de laranja foram escurecidos, CTAs em gradiente usam faixa mais escura, bottom nav usa fundo mais opaco e estado ativo sem amarelo claro sob texto branco, e o foco global passou a usar contorno solido de maior contraste.
+
+## Correcoes por prioridade
+
+### SF-FINAL-01 - Headers defensivos
+
+Corrigido em configuracao:
+
+- `vercel.json` na raiz agora declara `Content-Security-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` e `Permissions-Policy`.
+- `SIBiSC/vercel.json` manteve os headers e ajustou a CSP para permitir os fonts externos usados pelo CSS (`fonts.googleapis.com` e `fonts.gstatic.com`), evitando uma CSP que quebraria a tipografia.
+- `netlify.toml` recebeu headers equivalentes.
+
+Limite de validacao: headers de Vercel/Netlify nao sao servidos pelo `vite preview`; precisam ser confirmados no preview/deploy remoto do PR.
+
+### SF-FINAL-02 - HTTP 404 real
+
+Implementado por configuracao:
+
+- removido o rewrite global `/(.*) -> /index.html` da raiz Vercel;
+- mantidos rewrites somente para deep links conhecidos: `/home-mobile`, `/noticias`, detalhes canonicos, `/eventos`, detalhes canonicos, `/catalogo`, detalhes canonicos e `/perfil`;
+- removido o redirect catch-all do Netlify e substituido por redirects explicitos para as rotas conhecidas.
+
+Resultado esperado no deploy: rotas desconhecidas deixam de cair no fallback SPA e passam a receber 404 real do host estatico. Rotas existentes continuam funcionando em refresh/deep link.
+
+Limite de validacao: `vite preview` continua retornando `200` para rota inexistente por comportamento local de SPA fallback. A UI 404 acessivel segue renderizando corretamente.
+
+### SF-FINAL-03 - Contraste em gradientes/pseudo-elementos
+
+Mitigado em CSS:
+
+- `--color-accent` foi escurecido para contraste AA com texto branco;
+- `--color-accent-strong` foi escurecido para reforcar texto/acento em superficies claras;
+- definido `--color-ink-strong`, ja usado por modulos CSS;
+- foco global mudou de laranja translucido para contorno solido;
+- CTAs e bottom nav evitam texto branco sobre amarelo/laranja claro;
+- fundo da bottom nav ficou mais opaco e o link ativo usa gradiente escuro.
+
+Validacao automatizada previa ja tinha 0 violacoes axe WCAG A/AA nas rotas principais, mas com itens `incomplete` por gradientes/pseudo-elementos. Esta tarefa reduziu os riscos visuais evidentes; uma medicao manual completa pixel a pixel ainda e recomendada antes de declarar WCAG AA completa.
+
+### SF-FINAL-04 - Navegacao assistiva/mobile
+
+Corrigido em layout:
+
+- adicionado skip link `Pular para conteúdo principal`;
+- `main` recebeu `id="conteudo-principal"` e `tabIndex={-1}`;
+- ribbon informativa saiu de `div` solta e passou a `aside` rotulado;
+- footer recebeu `aria-labelledby`;
+- label da navegacao principal foi normalizada para `Navegação principal`;
+- bottom nav recebeu `id="navegacao-mobile"` e foi movida para antes do conteudo no DOM, mantendo `position: fixed` visual.
+
+No smoke mobile, a ordem inicial de foco ficou: skip link, marca, Início, Notícias, Eventos, Catálogo, Perfil, e depois controles do conteudo.
+
+## Validacoes executadas
+
+- `ReadLints` nos arquivos editados: sem erros.
+- `npm run qa:repo`: passou.
+- `npm run qa:ci`: passou, incluindo `vite build`.
+- Smoke Playwright em Microsoft Edge no `vite preview` local:
+  - `/`: `200`, h1 `Feltrim Agents ajuda você a encontrar a próxima leitura.`
+  - `/home-mobile`: `200`, h1 `Feltrim Agents`
+  - `/catalogo`: `200`, h1 `Catálogo`
+  - `/catalogo/b1`: `200`, h1 `Memorias Postumas de Bras Cubas`
+  - `/perfil`: `200`, h1 `João Silva`
+  - `/__sf_final_rota_inexistente__`: `200` local, UI 404 com h1 `Essa rota ainda não existe no mapa do SIBiSC.`
+  - console Edge: 0 errors, 0 warnings.
+
+## Pendencias reais
+
+- Confirmar no preview/deploy Vercel que os headers estao presentes no dominio efetivo.
+- Confirmar no preview/deploy Vercel que rota inexistente retorna HTTP 404 real.
+- Se houver deploy Netlify, confirmar que os redirects explicitos preservam deep links validos e deixam rotas desconhecidas em 404.
+- Fazer medicao manual completa de contraste em gradientes/pseudo-elementos antes de declarar conformidade WCAG AA completa.
+- Manter NO-GO para produto operacional real, reserva/renovacao oficial, integracao com biblioteca e compatibilidade auditada com NVDA/Narrator/VoiceOver ate validacoes dedicadas.

--- a/SIBiSC/src/components/layout/AppLayout.jsx
+++ b/SIBiSC/src/components/layout/AppLayout.jsx
@@ -24,6 +24,9 @@ function AppLayout() {
 
   return (
     <div className={styles.shell}>
+      <a className={styles.skipLink} href="#conteudo-principal">
+        Pular para conteúdo principal
+      </a>
       <div className={styles.backgroundGlow} />
 
       <header className={styles.header}>
@@ -43,7 +46,7 @@ function AppLayout() {
             </NavLink>
           </div>
 
-          <nav className={styles.desktopNav} aria-label="Navegacao principal">
+          <nav className={styles.desktopNav} aria-label="Navegação principal">
             {desktopItems.map((item) => (
               <NavLink
                 key={item.to}
@@ -66,22 +69,24 @@ function AppLayout() {
         </div>
       </header>
 
-      <div className={styles.ribbon}>
+      <BottomNav />
+
+      <aside className={styles.ribbon} aria-label="Resumo da rede SIBiSC">
         <div className={styles.ribbonInner}>
           {headlineFacts.map((fact) => (
             <span key={fact}>{fact}</span>
           ))}
         </div>
-      </div>
+      </aside>
 
-      <main className={styles.main}>
+      <main id="conteudo-principal" className={styles.main} tabIndex={-1}>
         <Outlet />
       </main>
 
-      <footer className={styles.footer}>
+      <footer className={styles.footer} aria-labelledby="sibisc-footer-title">
         <div className={styles.footerIntro}>
           <span className={styles.footerEyebrow}>Bibliotecas da rede</span>
-          <h2>Unidades, horários e contatos em um bloco compacto.</h2>
+          <h2 id="sibisc-footer-title">Unidades, horários e contatos em um bloco compacto.</h2>
           <p>
             Consulte horários, descubra eventos por bairro e encontre o melhor ponto de retirada
             para cada livro.
@@ -102,8 +107,6 @@ function AppLayout() {
           ))}
         </div>
       </footer>
-
-      <BottomNav />
     </div>
   );
 }

--- a/SIBiSC/src/components/layout/AppLayout.module.css
+++ b/SIBiSC/src/components/layout/AppLayout.module.css
@@ -4,6 +4,28 @@
   overflow: clip;
 }
 
+.skipLink {
+  position: fixed;
+  top: 0.75rem;
+  left: 50%;
+  z-index: 40;
+  min-height: 2.75rem;
+  padding: 0.72rem 1rem;
+  border-radius: var(--radius-pill);
+  color: white;
+  background: var(--color-navy);
+  box-shadow: var(--shadow-medium);
+  font-weight: 800;
+  transform: translate(-50%, -150%);
+  transition: transform 160ms ease;
+}
+
+.skipLink:focus-visible {
+  outline: 3px solid var(--color-highlight);
+  outline-offset: 3px;
+  transform: translate(-50%, 0);
+}
+
 .backgroundGlow {
   position: fixed;
   inset: auto 0 0 auto;
@@ -155,13 +177,17 @@
 
 .ctaLink {
   color: white;
-  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-strong));
+  background: linear-gradient(135deg, var(--color-accent), #8f3a1c);
   box-shadow: var(--shadow-soft);
 }
 
 .main {
   position: relative;
   z-index: 1;
+}
+
+.main:focus {
+  outline: none;
 }
 
 .ribbon {

--- a/SIBiSC/src/components/layout/BottomNav.jsx
+++ b/SIBiSC/src/components/layout/BottomNav.jsx
@@ -67,7 +67,7 @@ function NavIcon({ icon }) {
 
 function BottomNav() {
   return (
-    <nav className={styles.nav} aria-label="Navegação mobile">
+    <nav id="navegacao-mobile" className={styles.nav} aria-label="Navegação mobile">
       {navItems.map((item) => (
         <NavLink
           key={item.to}

--- a/SIBiSC/src/components/layout/BottomNav.module.css
+++ b/SIBiSC/src/components/layout/BottomNav.module.css
@@ -9,9 +9,9 @@
   gap: 0.18rem;
   width: min(90vw, 500px);
   padding: 0.34rem;
-  border: 1px solid rgba(255, 255, 255, 0.24);
+  border: 1px solid rgba(255, 255, 255, 0.32);
   border-radius: calc(var(--radius-pill) + 8px);
-  background: rgba(18, 38, 63, 0.76);
+  background: rgba(18, 38, 63, 0.92);
   box-shadow: 0 14px 38px rgba(18, 38, 63, 0.22);
   backdrop-filter: blur(18px);
   animation: nav-in 420ms ease both;
@@ -25,7 +25,7 @@
   padding: 0.46rem 0.22rem;
   border-radius: var(--radius-pill);
   text-align: center;
-  color: rgba(255, 255, 255, 0.72);
+  color: rgba(255, 255, 255, 0.84);
   font-size: 0.72rem;
   font-weight: 700;
   transition:
@@ -43,7 +43,7 @@
 }
 
 .link:focus-visible {
-  outline: 3px solid rgba(239, 178, 102, 0.42);
+  outline: 3px solid var(--color-highlight);
   outline-offset: 3px;
 }
 
@@ -53,7 +53,7 @@
 
 .linkActive {
   color: white;
-  background: linear-gradient(135deg, rgba(210, 100, 56, 0.95), rgba(239, 178, 102, 0.95));
+  background: linear-gradient(135deg, #8f3a1c, var(--color-navy));
   box-shadow: 0 10px 24px rgba(210, 100, 56, 0.24);
 }
 

--- a/SIBiSC/src/styles/globals.css
+++ b/SIBiSC/src/styles/globals.css
@@ -71,7 +71,7 @@ button {
 button:focus-visible,
 a:focus-visible,
 input:focus-visible {
-  outline: 3px solid rgba(210, 100, 56, 0.35);
+  outline: 3px solid var(--color-accent-strong);
   outline-offset: 3px;
 }
 

--- a/SIBiSC/src/styles/tokens.css
+++ b/SIBiSC/src/styles/tokens.css
@@ -4,6 +4,7 @@
   --font-mono: 'Space Mono', 'Cascadia Code', monospace;
 
   --color-ink: #12263f;
+  --color-ink-strong: #0d1d31;
   --color-ink-soft: #4b6078;
   --color-ink-muted: #73869c;
   --color-paper: #f5efe2;
@@ -13,8 +14,8 @@
   --color-surface-dark: rgba(18, 38, 63, 0.92);
   --color-line: rgba(18, 38, 63, 0.12);
   --color-line-strong: rgba(18, 38, 63, 0.24);
-  --color-accent: #d26438;
-  --color-accent-strong: #a34320;
+  --color-accent: #b84f28;
+  --color-accent-strong: #8f3a1c;
   --color-highlight: #efb266;
   --color-highlight-soft: rgba(239, 178, 102, 0.2);
   --color-success: #317a56;

--- a/SIBiSC/vercel.json
+++ b/SIBiSC/vercel.json
@@ -9,7 +9,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.supabase.co"
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://*.supabase.co"
         },
         {
           "key": "X-Content-Type-Options",

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,131 @@
   command = "npm ci && npm run build"
   publish = "dist"
 
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://*.supabase.co"
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "DENY"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=(), payment=()"
+
 [[redirects]]
-  from = "/*"
+  from = "/home-mobile"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/noticias"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/noticias/n1"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/noticias/n2"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/noticias/n3"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/noticias/n4"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/eventos"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/eventos/e1"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/eventos/e2"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/eventos/e3"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/eventos/e4"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/eventos/e5"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/eventos/e6"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/eventos/e7"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/catalogo"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/catalogo/b1"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/catalogo/b2"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/catalogo/b3"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/catalogo/b4"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/catalogo/b5"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/catalogo/b6"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/catalogo/b7"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/catalogo/b8"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/perfil"
   to = "/index.html"
   status = 200

--- a/vercel.json
+++ b/vercel.json
@@ -4,9 +4,64 @@
   "installCommand": "npm ci --prefix SIBiSC",
   "buildCommand": "npm run build --prefix SIBiSC",
   "outputDirectory": "SIBiSC/dist",
-  "rewrites": [
+  "headers": [
     {
       "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://*.supabase.co"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=()"
+        }
+      ]
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/home-mobile",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/noticias",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/noticias/:newsId(n1|n2|n3|n4)",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/eventos",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/eventos/:eventId(e1|e2|e3|e4|e5|e6|e7)",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/catalogo",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/catalogo/:bookId(b1|b2|b3|b4|b5|b6|b7|b8)",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/perfil",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
## Summary
- Adds defensive Vercel/Netlify headers in the effective root deploy config, with CSP adjusted for existing Google Fonts usage.
- Restricts SPA rewrites/redirects to known routes so unknown URLs can return real host 404s in deploy while valid deep links keep working.
- Improves assistive/mobile navigation with a skip link, clearer landmarks, earlier bottom nav focus order, stronger focus rings, and safer contrast tokens.
- Documents SF-FINAL-01 through SF-FINAL-04 validation results and remaining deploy-only limitations.

## Test plan
- ReadLints on edited code/config files: passed.
- `npm run qa:repo`: passed.
- `npm run qa:ci`: passed.
- Playwright smoke in Microsoft Edge on local `vite preview`: passed for `/`, `/home-mobile`, `/catalogo`, `/catalogo/b1`, `/perfil`, and a nonexistent route UI 404; console had 0 errors/warnings.
- Headers and HTTP 404 real still need confirmation on the Vercel/Netlify preview because `vite preview` does not apply host headers and keeps SPA fallback status `200` locally.